### PR TITLE
Rotate along ground selected objects

### DIFF
--- a/src/math/matrix_4x4.cpp
+++ b/src/math/matrix_4x4.cpp
@@ -89,11 +89,11 @@ namespace math
   }
 
   matrix_4x4::matrix_4x4(rotation_yxz_t, degrees::vec3 const& angle)
-      : matrix_4x4(unit)
+    : matrix_4x4(unit)
   {
-      *this *= rotate_axis<y>(angle.y);
-      *this *= rotate_axis<x>(angle.x);
-      *this *= rotate_axis<z>(angle.z);
+    *this *= rotate_axis<y>(angle.y);
+    *this *= rotate_axis<x>(angle.x);
+    *this *= rotate_axis<z>(angle.z);
   }
 
   vector_3d matrix_4x4::operator* (vector_3d const& v) const

--- a/src/math/matrix_4x4.cpp
+++ b/src/math/matrix_4x4.cpp
@@ -17,6 +17,7 @@ namespace math
   matrix_4x4::rotation_t matrix_4x4::rotation;
   matrix_4x4::rotation_xyz_t matrix_4x4::rotation_xyz;
   matrix_4x4::rotation_yzx_t matrix_4x4::rotation_yzx;
+  matrix_4x4::rotation_yxz_t matrix_4x4::rotation_yxz;
 
   matrix_4x4::matrix_4x4 (rotation_t, quaternion const& q)
   {
@@ -85,6 +86,14 @@ namespace math
     *this *= rotate_axis<y> (angle.y);
     *this *= rotate_axis<z> (angle.z);
     *this *= rotate_axis<x> (angle.x);
+  }
+
+  matrix_4x4::matrix_4x4(rotation_yxz_t, degrees::vec3 const& angle)
+      : matrix_4x4(unit)
+  {
+      *this *= rotate_axis<y>(angle.y);
+      *this *= rotate_axis<x>(angle.x);
+      *this *= rotate_axis<z>(angle.z);
   }
 
   vector_3d matrix_4x4::operator* (vector_3d const& v) const

--- a/src/math/matrix_4x4.hpp
+++ b/src/math/matrix_4x4.hpp
@@ -67,8 +67,12 @@ namespace math
 
     static struct rotation_xyz_t {} rotation_xyz;
     matrix_4x4 (rotation_xyz_t, degrees::vec3 const&);
+
     static struct rotation_yzx_t {} rotation_yzx;
     matrix_4x4 (rotation_yzx_t, degrees::vec3 const&);
+
+    static struct rotation_yxz_t {} rotation_yxz;
+    matrix_4x4(rotation_yxz_t, degrees::vec3 const&);
 
     float operator() (std::size_t const& j, std::size_t const& i) const
     {

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -9,52 +9,149 @@
 
 namespace math
 {
-  struct vector_3d;
+	struct vector_3d;
 
-  //! \note Actually, a typedef would be enough.
-  struct quaternion : public vector_4d
-  {
-  public:
-    quaternion()
-      : quaternion (0.f, 0.f, 0.f, 1.0f)
-    {}
+	struct quaternion : public vector_4d
+	{
+	public:
+		quaternion()
+			: quaternion(0.f, 0.f, 0.f, 1.0f)
+		{}
 
-   quaternion ( const float& x
-              , const float& y
-              , const float& z
-              , const float& w
-              )
-     : vector_4d (x, y, z, w)
-   { }
+		quaternion(const float& x
+			, const float& y
+			, const float& z
+			, const float& w
+		)
+			: vector_4d(x, y, z, w)
+		{ }
 
-   explicit quaternion (const vector_4d& v)
-     : vector_4d (v)
-   { }
+		explicit quaternion(const vector_4d& v)
+			: vector_4d(v)
+		{ }
 
-   quaternion (const vector_3d& v, const float w)
-     : vector_4d (v, w)
-   { }
-  };
+		quaternion(const vector_3d& v, const float w)
+			: vector_4d(v, w)
+		{ }
+		// heading = rotation around y
+		// attitude = rotation around z
+		// bank = rotation around x
+		quaternion(math::radians bank, math::radians heading, math::radians attitude) : vector_4d()
+		{
+			/*yawr._ *= 0.5f;
+			pitchr._ *= 0.5f;
+			rollr._ *= 0.5f;
 
-  //! \note "linear" interpolation for quaternions should be slerp by default.
-  namespace interpolation
-  {
-    template<>
-    inline quaternion linear ( const float& percentage
-                      , const quaternion& start
-                      , const quaternion& end
-                      )
-    {
-      return slerp (percentage, start, end);
-    }
-  }
+			// Abbreviations for the various angular functions
+			double cy = cos(yawr);
+			double sy = sin(yawr);
+			double cp = cos(pitchr);
+			double sp = sin(pitchr);
+			double cr = cos(rollr);
+			double sr = sin(rollr);
 
-  //! \note In WoW 2.0+ Blizzard is now storing rotation data in 16bit values instead of 32bit. I don't really understand why as its only a very minor saving in model sizes and adds extra overhead in processing the models. Need this structure to read the data into.
-  struct packed_quaternion
-  {
-    int16_t x;
-    int16_t y;
-    int16_t z;
-    int16_t w;
-  };
+			w = static_cast<float>(cr * cp * cy + sr * sp * sy);
+			x = static_cast<float>(sr * cp * cy - cr * sp * sy);
+			y = static_cast<float>(cr * sp * cy + sr * cp * sy);
+			z = static_cast<float>(cr * cp * sy - sr * sp * cy);*/
+			heading._ *= 0.5;
+			attitude._ *= 0.5;
+			bank._ *= 0.5;
+			// Assuming the angles are in radians.
+			double c1 = cos(heading );
+			double s1 = sin(heading );
+			double c2 = cos(attitude);
+			double s2 = sin(attitude );
+			double c3 = cos(bank );
+			double s3 = sin(bank );
+			double c1c2 = c1 * c2;
+			double s1s2 = s1 * s2;
+			w = static_cast<float>(c1c2 * c3 - s1s2 * s3);
+			x = static_cast<float>(c1c2 * s3 + s1s2 * c3);
+			y = static_cast<float>(s1 * c2 * c3 + c1 * s2 * s3);
+			z = static_cast<float>(c1 * s2 * c3 - s1 * c2 * s3);
+			
+		}
+
+		quaternion operator% (const quaternion& q2) const
+		{
+			float newx = x * q2.w + y * q2.z - z * q2.y + w * q2.x;
+			float newy = -x * q2.z + y * q2.w + z * q2.x + w * q2.y;
+			float newz = x * q2.y - y * q2.x + z * q2.w + w * q2.z;
+			float neww = -x * q2.x - y * q2.y - z * q2.z + w * q2.w;
+			return quaternion(newx, newy, newz, neww);
+		}
+
+		vector_3d ToEulerAngles() const {
+			/* // Old method, prone to gimbal lock!
+			double ex, ey, ez;
+			// roll (x-axis rotation)
+			double sinr_cosp = 2.0 * (w * x + y * z);
+			double cosr_cosp = 1.0 - 2.0 * (x * x + y * y);
+			ex = std::atan2(sinr_cosp, cosr_cosp) * 180.0f / math::constants::pi;
+
+			// pitch (y-axis rotation)
+			double sinp = 2.0 * (w * y - z * x);
+			if (std::abs(sinp) >= 1)
+				ey = std::copysign(math::constants::pi / 2, sinp) * 180.0f / math::constants::pi; // use 90 degrees if out of range
+			else
+				ey = std::asin(sinp) * 180.0f / math::constants::pi;
+
+			// yaw (z-axis rotation)
+			double siny_cosp = 2.0 * (w * z + x * y);
+			double cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
+			 ez = std::atan2(siny_cosp, cosy_cosp) * 180.0f / math::constants::pi;
+
+			return vector_3d(static_cast<float>(ex), static_cast<float>(ey), static_cast<float>(ez));
+			*/
+			math::vector_3d retVal;
+
+			double sqw = w * w;
+			double sqx = x * x;
+			double sqy = y * y;
+			double sqz = z * z;
+			double unit = sqx + sqy + sqz + sqw; // if normalised is one, otherwise is correction factor
+			double test = x * y + z * w;
+			if (test > 0.499 * unit) { // singularity at north pole
+				retVal.y = -static_cast<float>(2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
+				retVal.x = (math::constants::pi / 2) * 180.0f / math::constants::pi;
+				retVal.z = 0;
+				return retVal;
+			}
+			if (test < -0.499 * unit) { // singularity at south pole
+				retVal.y = -static_cast<float>(-2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
+				retVal.x = (-math::constants::pi / 2) * 180.0f / math::constants::pi;
+				retVal.z = 0;
+				return retVal;
+			}
+			retVal.y = -static_cast<float>(std::atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw) * 180.0f / math::constants::pi);
+			retVal.x = static_cast<float>(std::asin(2 * test / unit) * 180.0f / math::constants::pi);
+			retVal.z = static_cast<float>(std::atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw) * 180.0f / math::constants::pi);
+
+			return retVal;
+		}
+
+	};
+
+	//! \note "linear" interpolation for quaternions should be slerp by default.
+	namespace interpolation
+	{
+		template<>
+		inline quaternion linear(const float& percentage
+			, const quaternion& start
+			, const quaternion& end
+		)
+		{
+			return slerp(percentage, start, end);
+		}
+	}
+
+	//! \note In WoW 2.0+ Blizzard is now storing rotation data in 16bit values instead of 32bit. I don't really understand why as its only a very minor saving in model sizes and adds extra overhead in processing the models. Need this structure to read the data into.
+	struct packed_quaternion
+	{
+		int16_t x;
+		int16_t y;
+		int16_t z;
+		int16_t w;
+	};
 }

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -9,149 +9,114 @@
 
 namespace math
 {
-	struct vector_3d;
+  struct vector_3d;
 
-	struct quaternion : public vector_4d
-	{
-	public:
-		quaternion()
-			: quaternion(0.f, 0.f, 0.f, 1.0f)
-		{}
+  struct quaternion : public vector_4d
+  {
+  public:
+    quaternion()
+      : quaternion(0.f, 0.f, 0.f, 1.0f)
+    {}
 
-		quaternion(const float& x
-			, const float& y
-			, const float& z
-			, const float& w
-		)
-			: vector_4d(x, y, z, w)
-		{ }
+    quaternion(const float& x
+      , const float& y
+      , const float& z
+      , const float& w
+    )
+      : vector_4d(x, y, z, w)
+    { }
 
-		explicit quaternion(const vector_4d& v)
-			: vector_4d(v)
-		{ }
+    explicit quaternion(const vector_4d& v)
+      : vector_4d(v)
+    { }
 
-		quaternion(const vector_3d& v, const float w)
-			: vector_4d(v, w)
-		{ }
-		// heading = rotation around y
-		// attitude = rotation around z
-		// bank = rotation around x
-		quaternion(math::radians bank, math::radians heading, math::radians attitude) : vector_4d()
-		{
-			/*yawr._ *= 0.5f;
-			pitchr._ *= 0.5f;
-			rollr._ *= 0.5f;
+    quaternion(const vector_3d& v, const float w)
+      : vector_4d(v, w)
+    { }
+    // heading = rotation around y
+    // attitude = rotation around z
+    // bank = rotation around x
+    quaternion(math::radians bank, math::radians heading, math::radians attitude) : vector_4d()
+    {
+      heading._ *= 0.5;
+      attitude._ *= 0.5;
+      bank._ *= 0.5;
+      double c1 = cos(heading );
+      double s1 = sin(heading );
+      double c2 = cos(attitude);
+      double s2 = sin(attitude );
+      double c3 = cos(bank );
+      double s3 = sin(bank );
+      double c1c2 = c1 * c2;
+      double s1s2 = s1 * s2;
+      w = static_cast<float>(c1c2 * c3 - s1s2 * s3);
+      x = static_cast<float>(c1c2 * s3 + s1s2 * c3);
+      y = static_cast<float>(s1 * c2 * c3 + c1 * s2 * s3);
+      z = static_cast<float>(c1 * s2 * c3 - s1 * c2 * s3);
+    }
 
-			// Abbreviations for the various angular functions
-			double cy = cos(yawr);
-			double sy = sin(yawr);
-			double cp = cos(pitchr);
-			double sp = sin(pitchr);
-			double cr = cos(rollr);
-			double sr = sin(rollr);
+    quaternion operator% (const quaternion& q2) const
+    {
+      float newx = x * q2.w + y * q2.z - z * q2.y + w * q2.x;
+      float newy = -x * q2.z + y * q2.w + z * q2.x + w * q2.y;
+      float newz = x * q2.y - y * q2.x + z * q2.w + w * q2.z;
+      float neww = -x * q2.x - y * q2.y - z * q2.z + w * q2.w;
+      return quaternion(newx, newy, newz, neww);
+    }
 
-			w = static_cast<float>(cr * cp * cy + sr * sp * sy);
-			x = static_cast<float>(sr * cp * cy - cr * sp * sy);
-			y = static_cast<float>(cr * sp * cy + sr * cp * sy);
-			z = static_cast<float>(cr * cp * sy - sr * sp * cy);*/
-			heading._ *= 0.5;
-			attitude._ *= 0.5;
-			bank._ *= 0.5;
-			// Assuming the angles are in radians.
-			double c1 = cos(heading );
-			double s1 = sin(heading );
-			double c2 = cos(attitude);
-			double s2 = sin(attitude );
-			double c3 = cos(bank );
-			double s3 = sin(bank );
-			double c1c2 = c1 * c2;
-			double s1s2 = s1 * s2;
-			w = static_cast<float>(c1c2 * c3 - s1s2 * s3);
-			x = static_cast<float>(c1c2 * s3 + s1s2 * c3);
-			y = static_cast<float>(s1 * c2 * c3 + c1 * s2 * s3);
-			z = static_cast<float>(c1 * s2 * c3 - s1 * c2 * s3);
-			
-		}
+    vector_3d ToEulerAngles() const
+    {
+      math::vector_3d retVal;
 
-		quaternion operator% (const quaternion& q2) const
-		{
-			float newx = x * q2.w + y * q2.z - z * q2.y + w * q2.x;
-			float newy = -x * q2.z + y * q2.w + z * q2.x + w * q2.y;
-			float newz = x * q2.y - y * q2.x + z * q2.w + w * q2.z;
-			float neww = -x * q2.x - y * q2.y - z * q2.z + w * q2.w;
-			return quaternion(newx, newy, newz, neww);
-		}
+      double sqw = w * w;
+      double sqx = x * x;
+      double sqy = y * y;
+      double sqz = z * z;
+      double unit = sqx + sqy + sqz + sqw; // if normalised is one, otherwise is correction factor
+      double test = x * y + z * w;
+      if (test > 0.499 * unit) // singularity at north pole
+      {
+        retVal.y = -static_cast<float>(2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
+        retVal.x = (math::constants::pi / 2) * 180.0f / math::constants::pi;
+        retVal.z = 0;
+      }
+      else if (test < -0.499 * unit) // singularity at south pole
+      {
+        retVal.y = -static_cast<float>(-2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
+        retVal.x = (-math::constants::pi / 2) * 180.0f / math::constants::pi;
+        retVal.z = 0;
+      }
+      else
+      {
+	retVal.y = -static_cast<float>(std::atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw) * 180.0f / math::constants::pi);
+	retVal.x = static_cast<float>(std::asin(2 * test / unit) * 180.0f / math::constants::pi);
+	retVal.z = static_cast<float>(std::atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw) * 180.0f / math::constants::pi);
+      }
 
-		vector_3d ToEulerAngles() const {
-			/* // Old method, prone to gimbal lock!
-			double ex, ey, ez;
-			// roll (x-axis rotation)
-			double sinr_cosp = 2.0 * (w * x + y * z);
-			double cosr_cosp = 1.0 - 2.0 * (x * x + y * y);
-			ex = std::atan2(sinr_cosp, cosr_cosp) * 180.0f / math::constants::pi;
+      return retVal;
+    }
 
-			// pitch (y-axis rotation)
-			double sinp = 2.0 * (w * y - z * x);
-			if (std::abs(sinp) >= 1)
-				ey = std::copysign(math::constants::pi / 2, sinp) * 180.0f / math::constants::pi; // use 90 degrees if out of range
-			else
-				ey = std::asin(sinp) * 180.0f / math::constants::pi;
+  };
 
-			// yaw (z-axis rotation)
-			double siny_cosp = 2.0 * (w * z + x * y);
-			double cosy_cosp = 1.0 - 2.0 * (y * y + z * z);
-			 ez = std::atan2(siny_cosp, cosy_cosp) * 180.0f / math::constants::pi;
+  //! \note "linear" interpolation for quaternions should be slerp by default.
+  namespace interpolation
+  {
+    template<>
+    inline quaternion linear(const float& percentage
+      , const quaternion& start
+      , const quaternion& end
+    )
+    {
+      return slerp(percentage, start, end);
+    }
+  }
 
-			return vector_3d(static_cast<float>(ex), static_cast<float>(ey), static_cast<float>(ez));
-			*/
-			math::vector_3d retVal;
-
-			double sqw = w * w;
-			double sqx = x * x;
-			double sqy = y * y;
-			double sqz = z * z;
-			double unit = sqx + sqy + sqz + sqw; // if normalised is one, otherwise is correction factor
-			double test = x * y + z * w;
-			if (test > 0.499 * unit) { // singularity at north pole
-				retVal.y = -static_cast<float>(2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
-				retVal.x = (math::constants::pi / 2) * 180.0f / math::constants::pi;
-				retVal.z = 0;
-				return retVal;
-			}
-			if (test < -0.499 * unit) { // singularity at south pole
-				retVal.y = -static_cast<float>(-2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
-				retVal.x = (-math::constants::pi / 2) * 180.0f / math::constants::pi;
-				retVal.z = 0;
-				return retVal;
-			}
-			retVal.y = -static_cast<float>(std::atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw) * 180.0f / math::constants::pi);
-			retVal.x = static_cast<float>(std::asin(2 * test / unit) * 180.0f / math::constants::pi);
-			retVal.z = static_cast<float>(std::atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw) * 180.0f / math::constants::pi);
-
-			return retVal;
-		}
-
-	};
-
-	//! \note "linear" interpolation for quaternions should be slerp by default.
-	namespace interpolation
-	{
-		template<>
-		inline quaternion linear(const float& percentage
-			, const quaternion& start
-			, const quaternion& end
-		)
-		{
-			return slerp(percentage, start, end);
-		}
-	}
-
-	//! \note In WoW 2.0+ Blizzard is now storing rotation data in 16bit values instead of 32bit. I don't really understand why as its only a very minor saving in model sizes and adds extra overhead in processing the models. Need this structure to read the data into.
-	struct packed_quaternion
-	{
-		int16_t x;
-		int16_t y;
-		int16_t z;
-		int16_t w;
-	};
+  //! \note In WoW 2.0+ Blizzard is now storing rotation data in 16bit values instead of 32bit. I don't really understand why as its only a very minor saving in model sizes and adds extra overhead in processing the models. Need this structure to read the data into.
+  struct packed_quaternion
+  {
+    int16_t x;
+    int16_t y;
+    int16_t z;
+    int16_t w;
+  };
 }

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -15,24 +15,25 @@ namespace math
   {
   public:
     quaternion()
-      : quaternion(0.f, 0.f, 0.f, 1.0f)
+      : quaternion (0.f, 0.f, 0.f, 1.0f)
     {}
 
-    quaternion(const float& x
-      , const float& y
-      , const float& z
-      , const float& w
-    )
+    quaternion ( const float& x
+               , const float& y
+               , const float& z
+               , const float& w
+               )
       : vector_4d(x, y, z, w)
     { }
 
-    explicit quaternion(const vector_4d& v)
+    explicit quaternion (const vector_4d& v)
       : vector_4d(v)
     { }
 
-    quaternion(const vector_3d& v, const float w)
+    quaternion (const vector_3d& v, const float w)
       : vector_4d(v, w)
     { }
+
     // heading = rotation around y
     // attitude = rotation around z
     // bank = rotation around x
@@ -95,19 +96,18 @@ namespace math
 
       return retVal;
     }
-
   };
 
   //! \note "linear" interpolation for quaternions should be slerp by default.
   namespace interpolation
   {
     template<>
-    inline quaternion linear(const float& percentage
-      , const quaternion& start
-      , const quaternion& end
-    )
+    inline quaternion linear ( const float& percentage
+                             , const quaternion& start
+                             , const quaternion& end
+                             )
     {
-      return slerp(percentage, start, end);
+      return slerp (percentage, start, end);
     }
   }
 

--- a/src/noggit/MapChunk.cpp
+++ b/src/noggit/MapChunk.cpp
@@ -632,7 +632,7 @@ void MapChunk::intersect (math::ray const& ray, selection_result* results)
        )
     {
       results->emplace_back
-        (*distance, selected_chunk_type (this, strip_without_holes[i + 0], ray.position (*distance)));
+        (*distance, selected_chunk_type (this, std::make_tuple(strip_without_holes[i], strip_without_holes[i + 1], strip_without_holes[i + 2]), ray.position (*distance)));
     }
   }
 }

--- a/src/noggit/MapChunk.cpp
+++ b/src/noggit/MapChunk.cpp
@@ -632,7 +632,16 @@ void MapChunk::intersect (math::ray const& ray, selection_result* results)
        )
     {
       results->emplace_back
-        (*distance, selected_chunk_type (this, std::make_tuple(strip_without_holes[i], strip_without_holes[i + 1], strip_without_holes[i + 2]), ray.position (*distance)));
+        ( *distance
+	, selected_chunk_type
+	    ( this
+	    , std::make_tuple ( strip_without_holes[i]
+			      , strip_without_holes[i + 1]
+			      , strip_without_holes[i + 2]
+			      )
+	    , ray.position (*distance)
+	    )
+	);
     }
   }
 }

--- a/src/noggit/MapChunk.cpp
+++ b/src/noggit/MapChunk.cpp
@@ -633,15 +633,15 @@ void MapChunk::intersect (math::ray const& ray, selection_result* results)
     {
       results->emplace_back
         ( *distance
-	, selected_chunk_type
-	    ( this
-	    , std::make_tuple ( strip_without_holes[i]
-			      , strip_without_holes[i + 1]
-			      , strip_without_holes[i + 2]
-			      )
-	    , ray.position (*distance)
-	    )
-	);
+        , selected_chunk_type
+            ( this
+            , std::make_tuple ( strip_without_holes[i]
+                              , strip_without_holes[i + 1]
+                              , strip_without_holes[i + 2]
+                              )
+            , ray.position (*distance)
+            )
+        );
     }
   }
 }

--- a/src/noggit/MapChunk.cpp
+++ b/src/noggit/MapChunk.cpp
@@ -632,7 +632,7 @@ void MapChunk::intersect (math::ray const& ray, selection_result* results)
        )
     {
       results->emplace_back
-        (*distance, selected_chunk_type (this, i, ray.position (*distance)));
+        (*distance, selected_chunk_type (this, strip_without_holes[i + 0], ray.position (*distance)));
     }
   }
 }

--- a/src/noggit/MapChunk.h
+++ b/src/noggit/MapChunk.h
@@ -51,7 +51,6 @@ private:
   std::vector<StripType> strip_without_holes;
   std::map<int, std::vector<StripType>> strip_lods;
 
-  math::vector_3d mNormals[mapbufsize];
   math::vector_3d mccv[mapbufsize];
 
   std::vector<uint8_t> compressed_shadow_map() const;
@@ -103,6 +102,7 @@ public:
 
   std::unique_ptr<TextureSet> texture_set;
 
+  math::vector_3d mNormals[mapbufsize];
   math::vector_3d mVertices[mapbufsize];
 
   bool is_visible ( const float& cull_distance

--- a/src/noggit/MapView.cpp
+++ b/src/noggit/MapView.cpp
@@ -1735,8 +1735,8 @@ void MapView::tick (float dt)
 
           if (snapped && _rotate_along_ground.get())
           {
-	    _world->rotate_selected_models_to_ground_normal(_rotate_along_ground_smooth.get());
-	    if (_rotate_along_ground_random.get())
+            _world->rotate_selected_models_to_ground_normal(_rotate_along_ground_smooth.get());
+            if (_rotate_along_ground_random.get())
             {
 	      float minX = 0, maxX = 0, minY = 0, maxY = 0, minZ = 0, maxZ = 0;
 

--- a/src/noggit/MapView.cpp
+++ b/src/noggit/MapView.cpp
@@ -1709,7 +1709,7 @@ void MapView::tick (float dt)
           if (_world->has_multiple_model_selected())
           {
             _world->set_selected_models_pos(_cursor_pos, false);
-
+            
             if (_snap_multi_selection_to_ground.get())
             {
               snap_selected_models_to_the_ground();
@@ -1717,13 +1717,18 @@ void MapView::tick (float dt)
           }
           else
           {
+            
             if (!_move_model_to_cursor_position.get())
             {
               _world->move_selected_models((mv * dirUp - mh * dirRight)*80.f);
             }
             else
             {
+
               _world->set_selected_models_pos(_cursor_pos, false);
+
+              _world->rotate_selected_models_to_ground_normal();
+
             }
           }
         }
@@ -2275,7 +2280,10 @@ void MapView::update_cursor_pos()
   {
     auto const& hit(results.front().second);
     // hit cannot be something else than a chunk
-    _cursor_pos = boost::get<selected_chunk_type>(hit).position;
+    auto const& chunkHit = boost::get<selected_chunk_type>(hit);
+    _cursor_pos = chunkHit.position;
+    _cursor_tri = chunkHit.triangle;
+    _cursor_chunk = chunkHit.chunk;
   }
 }
 

--- a/src/noggit/MapView.cpp
+++ b/src/noggit/MapView.cpp
@@ -261,6 +261,8 @@ void MapView::createGUI()
     , &_snap_multi_selection_to_ground
     , &_use_median_pivot_point
     , &_object_paste_params
+    , &_rotate_along_ground
+    , &_rotate_along_ground_smooth
     , _object_editor_dock
   );
   _object_editor_dock->setWidget(objectEditor);
@@ -1713,6 +1715,8 @@ void MapView::tick (float dt)
             if (_snap_multi_selection_to_ground.get())
             {
               snap_selected_models_to_the_ground();
+              if(_rotate_along_ground.get())
+                _world->rotate_selected_models_to_ground_normal(_rotate_along_ground_smooth.get());
             }
           }
           else
@@ -1724,10 +1728,10 @@ void MapView::tick (float dt)
             }
             else
             {
-
               _world->set_selected_models_pos(_cursor_pos, false);
 
-              _world->rotate_selected_models_to_ground_normal();
+              if (_rotate_along_ground.get())
+                _world->rotate_selected_models_to_ground_normal(_rotate_along_ground_smooth.get());
 
             }
           }
@@ -2282,8 +2286,6 @@ void MapView::update_cursor_pos()
     // hit cannot be something else than a chunk
     auto const& chunkHit = boost::get<selected_chunk_type>(hit);
     _cursor_pos = chunkHit.position;
-    _cursor_tri = chunkHit.triangle;
-    _cursor_chunk = chunkHit.chunk;
   }
 }
 

--- a/src/noggit/MapView.cpp
+++ b/src/noggit/MapView.cpp
@@ -2314,8 +2314,7 @@ void MapView::update_cursor_pos()
   {
     auto const& hit(results.front().second);
     // hit cannot be something else than a chunk
-    auto const& chunkHit = boost::get<selected_chunk_type>(hit);
-    _cursor_pos = chunkHit.position;
+    _cursor_pos = boost::get<selected_chunk_type>(hit).position;
   }
 }
 

--- a/src/noggit/MapView.cpp
+++ b/src/noggit/MapView.cpp
@@ -1713,17 +1713,15 @@ void MapView::tick (float dt)
           if (_world->has_multiple_model_selected())
           {
             _world->set_selected_models_pos(_cursor_pos, false);
-            
+
             if (_snap_multi_selection_to_ground.get())
             {
-              
               snap_selected_models_to_the_ground();
               snapped = true;
             }
           }
           else
           {
-            
             if (!_move_model_to_cursor_position.get())
             {
               _world->move_selected_models((mv * dirUp - mh * dirRight)*80.f);
@@ -1731,51 +1729,42 @@ void MapView::tick (float dt)
             else
             {
               _world->set_selected_models_pos(_cursor_pos, false);
-
               snapped = true;
-
             }
           }
 
           if (snapped && _rotate_along_ground.get())
           {
-              _world->rotate_selected_models_to_ground_normal(_rotate_along_ground_smooth.get());
-              if (_rotate_along_ground_random.get())
-              {
-                  float minX = 0, maxX = 0, minY = 0, maxY = 0, minZ = 0, maxZ = 0;
+	    _world->rotate_selected_models_to_ground_normal(_rotate_along_ground_smooth.get());
+	    if (_rotate_along_ground_random.get())
+            {
+	      float minX = 0, maxX = 0, minY = 0, maxY = 0, minZ = 0, maxZ = 0;
 
-                  if (_settings->value("model/random_rotation", false).toBool())
-                  {
-                      minY = _object_paste_params.minRotation;
-                      maxY = _object_paste_params.maxRotation;
-                  }
+	      if (_settings->value("model/random_rotation", false).toBool())
+	      {
+		minY = _object_paste_params.minRotation;
+		maxY = _object_paste_params.maxRotation;
+	      }
 
-                  if (_settings->value("model/random_tilt", false).toBool())
-                  {
-                      minX = _object_paste_params.minTilt;
-                      maxX = _object_paste_params.maxTilt;
-                      minZ = minX;
-                      maxZ = maxX;
-                  }
+	      if (_settings->value("model/random_tilt", false).toBool())
+	      {
+		minX = _object_paste_params.minTilt;
+		maxX = _object_paste_params.maxTilt;
+		minZ = minX;
+		maxZ = maxX;
+	      }
 
-                _world->rotate_selected_models_randomly(
-                    minX,
-                    maxX,
-                    minY,
-                    maxY,
-                    minZ,
-                    maxZ);
+	      _world->rotate_selected_models_randomly (minX, maxX, minY, maxY, minZ, maxZ);
 
-                  if (_settings->value("model/random_size", false).toBool())
-                  {
-                      float min = _object_paste_params.minScale;
-                      float max = _object_paste_params.maxScale;
+	      if (_settings->value("model/random_size", false).toBool())
+	      {
+		float min = _object_paste_params.minScale;
+		float max = _object_paste_params.maxScale;
 
-                      _world->scale_selected_models(misc::randfloat(min, max), World::m2_scaling_type::set);
-                  }
-              }
+		_world->scale_selected_models(misc::randfloat(min, max), World::m2_scaling_type::set);
+	      }
+	    }
           }
-          
         }
 
         _rotation_editor_need_update = true;

--- a/src/noggit/MapView.h
+++ b/src/noggit/MapView.h
@@ -73,6 +73,9 @@ private:
   float _2d_zoom = 1.f;
   float moving, strafing, updown, mousedir, turn, lookat;
   math::vector_3d _cursor_pos;
+  int _cursor_tri;
+  MapChunk* _cursor_chunk;
+
   bool look, freelook;
   bool ui_hidden = false;
 

--- a/src/noggit/MapView.h
+++ b/src/noggit/MapView.h
@@ -73,8 +73,6 @@ private:
   float _2d_zoom = 1.f;
   float moving, strafing, updown, mousedir, turn, lookat;
   math::vector_3d _cursor_pos;
-  int _cursor_tri;
-  MapChunk* _cursor_chunk;
 
   bool look, freelook;
   bool ui_hidden = false;
@@ -264,6 +262,9 @@ private:
   noggit::bool_toggle_property _locked_cursor_mode = {false};
   noggit::bool_toggle_property _move_model_to_cursor_position = {true};
   noggit::bool_toggle_property _snap_multi_selection_to_ground = {false};
+  noggit::bool_toggle_property _rotate_along_ground = { true };
+  noggit::bool_toggle_property _rotate_along_ground_smooth = { true };
+
   noggit::bool_toggle_property _use_median_pivot_point = {true};
   noggit::bool_toggle_property _display_all_water_layers = {true};
   noggit::unsigned_int_property _displayed_water_layer = {0};

--- a/src/noggit/MapView.h
+++ b/src/noggit/MapView.h
@@ -264,6 +264,7 @@ private:
   noggit::bool_toggle_property _snap_multi_selection_to_ground = {false};
   noggit::bool_toggle_property _rotate_along_ground = { true };
   noggit::bool_toggle_property _rotate_along_ground_smooth = { true };
+  noggit::bool_toggle_property _rotate_along_ground_random = { false };
 
   noggit::bool_toggle_property _use_median_pivot_point = {true};
   noggit::bool_toggle_property _display_all_water_layers = {true};

--- a/src/noggit/Selection.h
+++ b/src/noggit/Selection.h
@@ -15,14 +15,14 @@ class MapChunk;
 
 struct selected_chunk_type
 {
-  selected_chunk_type(MapChunk* _chunk, int _triangle, math::vector_3d _position)
+  selected_chunk_type(MapChunk* _chunk, std::tuple<int, int, int> _triangle, math::vector_3d _position)
     : chunk(_chunk)
     , triangle(_triangle)
     , position(_position)
   {}
 
   MapChunk* chunk;
-  int triangle;
+  std::tuple<int,int,int> triangle; // mVertices[i] points of the hit triangle
   math::vector_3d position;
 
   bool operator== (selected_chunk_type const& other) const

--- a/src/noggit/World.cpp
+++ b/src/noggit/World.cpp
@@ -992,7 +992,6 @@ void World::draw ( math::matrix_4x4 const& model_view
                                          , wmo.group_extents
                                          );
           }
-
         }
         , [&] () { return hadSky; }
       );

--- a/src/noggit/World.cpp
+++ b/src/noggit/World.cpp
@@ -524,8 +524,6 @@ void World::rotate_selected_models(math::degrees rx, math::degrees ry, math::deg
 
 void World::rotate_selected_models_randomly(float minX, float maxX, float minY, float maxY, float minZ, float maxZ)
 {
-    bool has_multi_select = has_multiple_model_selected();
-
     for (auto& entry : _current_selection)
     {
         auto type = entry.which();

--- a/src/noggit/World.cpp
+++ b/src/noggit/World.cpp
@@ -602,13 +602,15 @@ void World::set_selected_models_rotation(math::degrees rx, math::degrees ry, mat
   }
 }
 
-math::vector_3d getBarycentricCoordinatesAt(
+namespace
+{
+  math::vector_3d getBarycentricCoordinatesAt(
     const math::vector_3d& a, 
     const math::vector_3d& b, 
     const math::vector_3d& c, 
     const math::vector_3d& point, 
     const math::vector_3d& normal)
-{
+  {
     math::vector_3d bary;
 
     // The area of a triangle is 
@@ -622,6 +624,7 @@ math::vector_3d getBarycentricCoordinatesAt(
     bary.z = 1.0f - bary.x - bary.y; // gamma
 
     return bary;
+  }
 }
 
 void World::rotate_selected_models_to_ground_normal(bool smoothNormals)

--- a/src/noggit/World.h
+++ b/src/noggit/World.h
@@ -186,7 +186,7 @@ public:
   void rotate_selected_models(math::degrees rx, math::degrees ry, math::degrees rz, bool use_pivot);
   void set_selected_models_rotation(math::degrees rx, math::degrees ry, math::degrees rz);
   // Checks the normal of the terrain on model origin and rotates to that spot.
-  void rotate_selected_models_to_ground_normal();
+  void rotate_selected_models_to_ground_normal(bool smoothNormals);
   
 
   bool GetVertex(float x, float z, math::vector_3d *V) const;

--- a/src/noggit/World.h
+++ b/src/noggit/World.h
@@ -184,6 +184,7 @@ public:
   }
   void set_selected_models_pos(math::vector_3d const& pos, bool change_height = true);
   void rotate_selected_models(math::degrees rx, math::degrees ry, math::degrees rz, bool use_pivot);
+  void rotate_selected_models_randomly(float minX, float maxX, float minY, float maxY, float minZ, float maxZ);
   void set_selected_models_rotation(math::degrees rx, math::degrees ry, math::degrees rz);
   // Checks the normal of the terrain on model origin and rotates to that spot.
   void rotate_selected_models_to_ground_normal(bool smoothNormals);

--- a/src/noggit/World.h
+++ b/src/noggit/World.h
@@ -188,7 +188,6 @@ public:
   void set_selected_models_rotation(math::degrees rx, math::degrees ry, math::degrees rz);
   // Checks the normal of the terrain on model origin and rotates to that spot.
   void rotate_selected_models_to_ground_normal(bool smoothNormals);
-  
 
   bool GetVertex(float x, float z, math::vector_3d *V) const;
 

--- a/src/noggit/World.h
+++ b/src/noggit/World.h
@@ -185,6 +185,9 @@ public:
   void set_selected_models_pos(math::vector_3d const& pos, bool change_height = true);
   void rotate_selected_models(math::degrees rx, math::degrees ry, math::degrees rz, bool use_pivot);
   void set_selected_models_rotation(math::degrees rx, math::degrees ry, math::degrees rz);
+  // Checks the normal of the terrain on model origin and rotates to that spot.
+  void rotate_selected_models_to_ground_normal();
+  
 
   bool GetVertex(float x, float z, math::vector_3d *V) const;
 

--- a/src/noggit/ui/ObjectEditor.cpp
+++ b/src/noggit/ui/ObjectEditor.cpp
@@ -40,6 +40,8 @@ namespace noggit
                                  , bool_toggle_property* snap_multi_selection_to_ground
                                  , bool_toggle_property* use_median_pivot_point
                                  , object_paste_params* paste_params
+                                 , bool_toggle_property* rotate_along_ground
+                                 , bool_toggle_property* rotate_along_ground_smooth
                                  , QWidget* parent
                                  )
             : QWidget(parent)
@@ -141,8 +143,21 @@ namespace noggit
                                              , this
                                              )
                               );
+      auto object_rotateground_cb(new checkbox("Rotate when following cursor"
+          , rotate_along_ground
+          , this
+      )
+      );
+
+      auto object_rotategroundsmooth_cb(new checkbox("Smooth follow rotation"
+          , rotate_along_ground_smooth
+          , this
+      )
+      );
 
       object_movement_layout->addRow(object_movement_cb);
+      object_movement_layout->addRow(object_rotateground_cb);
+      object_movement_layout->addRow(object_rotategroundsmooth_cb);
 
       // multi model selection
       auto multi_select_movement_box(new QGroupBox("Multi Selection Movement", this));

--- a/src/noggit/ui/ObjectEditor.cpp
+++ b/src/noggit/ui/ObjectEditor.cpp
@@ -144,7 +144,7 @@ namespace noggit
                                              , this
                                              )
                               );
-     
+
       object_movement_layout->addRow(object_movement_cb);
 
       // multi model selection

--- a/src/noggit/ui/ObjectEditor.cpp
+++ b/src/noggit/ui/ObjectEditor.cpp
@@ -42,6 +42,7 @@ namespace noggit
                                  , object_paste_params* paste_params
                                  , bool_toggle_property* rotate_along_ground
                                  , bool_toggle_property* rotate_along_ground_smooth
+                                 , bool_toggle_property* rotate_along_ground_random
                                  , QWidget* parent
                                  )
             : QWidget(parent)
@@ -143,21 +144,8 @@ namespace noggit
                                              , this
                                              )
                               );
-      auto object_rotateground_cb(new checkbox("Rotate when following cursor"
-          , rotate_along_ground
-          , this
-      )
-      );
-
-      auto object_rotategroundsmooth_cb(new checkbox("Smooth follow rotation"
-          , rotate_along_ground_smooth
-          , this
-      )
-      );
-
+     
       object_movement_layout->addRow(object_movement_cb);
-      object_movement_layout->addRow(object_rotateground_cb);
-      object_movement_layout->addRow(object_rotategroundsmooth_cb);
 
       // multi model selection
       auto multi_select_movement_box(new QGroupBox("Multi Selection Movement", this));
@@ -178,6 +166,31 @@ namespace noggit
       
       multi_select_movement_layout->addRow(multi_select_movement_cb);
       multi_select_movement_layout->addRow(object_median_pivot_point);
+
+      auto object_rot_box(new QGroupBox("Follow Ground Rotation", this));
+      auto object_rot_layout = new QFormLayout(object_rot_box);
+
+      auto object_rotateground_cb(new checkbox("Rotate following cursor"
+          , rotate_along_ground
+          , this
+      )
+      );
+
+      auto object_rotategroundsmooth_cb(new checkbox("Smooth follow rotation"
+          , rotate_along_ground_smooth
+          , this
+      )
+      );
+
+      auto object_rotategroundrandom_cb(new checkbox("Random rot/tilt/scale\n on rotate"
+          , rotate_along_ground_random
+          , this
+      )
+      );
+
+      object_rot_layout->addRow(object_rotateground_cb);
+      object_rot_layout->addRow(object_rotategroundsmooth_cb);
+      object_rot_layout->addRow(object_rotategroundrandom_cb);
 
       QPushButton *rotEditorButton = new QPushButton("Pos/Rotation Editor", this);
       QPushButton *visToggleButton = new QPushButton("Toggle Hidden Models Visibility", this);
@@ -202,6 +215,7 @@ namespace noggit
       layout->addRow(pasteBox);
       layout->addRow(object_movement_box);
       layout->addRow(multi_select_movement_box);
+      layout->addRow(object_rot_box);
       layout->addRow(rotEditorButton);
       layout->addRow(visToggleButton);
       layout->addRow(clearListButton);

--- a/src/noggit/ui/ObjectEditor.cpp
+++ b/src/noggit/ui/ObjectEditor.cpp
@@ -170,24 +170,22 @@ namespace noggit
       auto object_rot_box(new QGroupBox("Follow Ground Rotation", this));
       auto object_rot_layout = new QFormLayout(object_rot_box);
 
-      auto object_rotateground_cb(new checkbox("Rotate following cursor"
-          , rotate_along_ground
-          , this
-      )
-      );
+      auto object_rotateground_cb ( new checkbox ( "Rotate following cursor"
+                                                 , rotate_along_ground
+                                                 , this
+                                                 )
+                                  );
+      auto object_rotategroundsmooth_cb ( new checkbox ( "Smooth follow rotation"
+                                                       , rotate_along_ground_smooth
+                                                       , this
+                                                       )
+                                        );
 
-      auto object_rotategroundsmooth_cb(new checkbox("Smooth follow rotation"
-          , rotate_along_ground_smooth
-          , this
-      )
-      );
-
-      auto object_rotategroundrandom_cb(new checkbox("Random rot/tilt/scale\n on rotate"
-          , rotate_along_ground_random
-          , this
-      )
-      );
-
+      auto object_rotategroundrandom_cb ( new checkbox ( "Random rot/tilt/scale\n on rotate"
+                                                       , rotate_along_ground_random
+                                                       , this
+                                                       )
+                                        );
       object_rot_layout->addRow(object_rotateground_cb);
       object_rot_layout->addRow(object_rotategroundsmooth_cb);
       object_rot_layout->addRow(object_rotategroundrandom_cb);

--- a/src/noggit/ui/ObjectEditor.h
+++ b/src/noggit/ui/ObjectEditor.h
@@ -59,6 +59,7 @@ namespace noggit
                     , object_paste_params*
                     , bool_toggle_property* rotate_along_ground
                     , bool_toggle_property* rotate_along_ground_smooth
+                    , bool_toggle_property* rotate_along_ground_random
                     , QWidget* parent = nullptr
                     );
 

--- a/src/noggit/ui/ObjectEditor.h
+++ b/src/noggit/ui/ObjectEditor.h
@@ -57,6 +57,8 @@ namespace noggit
                     , bool_toggle_property* snap_multi_selection_to_ground
                     , bool_toggle_property* use_median_pivot_point
                     , object_paste_params*
+                    , bool_toggle_property* rotate_along_ground
+                    , bool_toggle_property* rotate_along_ground_smooth
                     , QWidget* parent = nullptr
                     );
 

--- a/src/noggit/ui/RotationEditor.cpp
+++ b/src/noggit/ui/RotationEditor.cpp
@@ -44,15 +44,15 @@ namespace noggit
       layout->addRow(new QLabel("- rotation and scale only\n  change when pressing enter", this));
       layout->addRow(new QLabel("- scaling is multiplicative", this));
 
-      _rotation_x->setRange (-180.f, 180.f);
+      _rotation_x->setRange (-1800.f, 1800.f);
       _rotation_x->setDecimals (3);
       _rotation_x->setWrapping(true);
       _rotation_x->setSingleStep(5.0f);
-      _rotation_z->setRange (-180.f, 180.f);
+      _rotation_z->setRange (-1800.f, 1800.f);
       _rotation_z->setDecimals (3);
       _rotation_z->setWrapping(true);
       _rotation_z->setSingleStep(5.0f);
-      _rotation_y->setRange (0.f, 360.f);
+      _rotation_y->setRange (-1800.f, 3600.f);
       _rotation_y->setDecimals (3);
       _rotation_y->setWrapping(true);
       _rotation_y->setSingleStep(5.0f);


### PR DESCRIPTION
Added checkboxes that allow you to enable rotating models automatically as they follow the ground when moved.
When rotating, a checkbox controls the addition of local random rotation, that respects the terrain-following.

Rotation supports exact-to-face-normal, or smoothed out with nearby vertices. Latter is the default.

This was my first attempt at working on Noggit, required a bit more math than I thought was needed to start with as there was a serious lack of features in terms of quaternions and working with v/f-normals, but I worked that in the math classes.

I'm not sure if I followed the noggit coding style properly, so if there's something off do let me know.

This shows all the features used at once:

https://user-images.githubusercontent.com/3650235/105620100-9734ec80-5df9-11eb-99f8-eb0b74ea3164.mp4

