### PR TITLE
normalize model rotation to interface limits

### DIFF
--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -65,9 +65,9 @@ namespace math
       return quaternion(newx, newy, newz, neww);
     }
 
-    vector_3d ToEulerAngles() const
+    degrees::vec3 ToEulerAngles() const
     {
-      math::vector_3d retVal;
+      math::degrees::vec3 retVal;
 
       double sqw = w * w;
       double sqx = x * x;
@@ -77,21 +77,21 @@ namespace math
       double test = x * y + z * w;
       if (test > 0.499 * unit) // singularity at north pole
       {
-        retVal.y = -static_cast<float>(2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
-        retVal.x = (math::constants::pi / 2) * 180.0f / math::constants::pi;
-        retVal.z = 0;
+        retVal.y = math::degrees(-static_cast<float>(2.0f * std::atan2(x, w) * 180.0f / math::constants::pi));
+        retVal.x = math::degrees((math::constants::pi / 2) * 180.0f / math::constants::pi);
+        retVal.z = 0_deg;
       }
       else if (test < -0.499 * unit) // singularity at south pole
       {
-        retVal.y = -static_cast<float>(-2.0f * std::atan2(x, w) * 180.0f / math::constants::pi);
-        retVal.x = (-math::constants::pi / 2) * 180.0f / math::constants::pi;
-        retVal.z = 0;
+        retVal.y = math::degrees(-static_cast<float>(-2.0f * std::atan2(x, w) * 180.0f / math::constants::pi));
+        retVal.x = math::degrees((-math::constants::pi / 2) * 180.0f / math::constants::pi);
+        retVal.z = 0_deg;
       }
       else
       {
-	retVal.y = -static_cast<float>(std::atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw) * 180.0f / math::constants::pi);
-	retVal.x = static_cast<float>(std::asin(2 * test / unit) * 180.0f / math::constants::pi);
-	retVal.z = static_cast<float>(std::atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw) * 180.0f / math::constants::pi);
+        retVal.y = math::degrees(-static_cast<float>(std::atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw) * 180.0f / math::constants::pi));
+        retVal.x = math::degrees(static_cast<float>(std::asin(2 * test / unit) * 180.0f / math::constants::pi));
+        retVal.z = math::degrees(static_cast<float>(std::atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw) * 180.0f / math::constants::pi));
       }
 
       return retVal;

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -77,21 +77,21 @@ namespace math
       double test = x * y + z * w;
       if (test > 0.499 * unit) // singularity at north pole
       {
-        retVal.y = math::degrees(-static_cast<float>(2.0f * std::atan2(x, w) * 180.0f / math::constants::pi));
-        retVal.x = math::degrees((math::constants::pi / 2) * 180.0f / math::constants::pi);
+        retVal.y = -math::degrees(math::radians(2.0f * std::atan2(x, w)));
+        retVal.x = math::degrees(math::radians(math::constants::pi / 2));
         retVal.z = 0_deg;
       }
       else if (test < -0.499 * unit) // singularity at south pole
       {
-        retVal.y = math::degrees(-static_cast<float>(-2.0f * std::atan2(x, w) * 180.0f / math::constants::pi));
-        retVal.x = math::degrees((-math::constants::pi / 2) * 180.0f / math::constants::pi);
+        retVal.y = -math::degrees(math::radians(-2.0f * std::atan2(x, w)));
+        retVal.x = -math::degrees(math::radians(math::constants::pi / 2));
         retVal.z = 0_deg;
       }
       else
       {
-        retVal.y = math::degrees(-static_cast<float>(std::atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw) * 180.0f / math::constants::pi));
-        retVal.x = math::degrees(static_cast<float>(std::asin(2 * test / unit) * 180.0f / math::constants::pi));
-        retVal.z = math::degrees(static_cast<float>(std::atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw) * 180.0f / math::constants::pi));
+        retVal.y = -math::degrees(math::radians(std::atan2(2 * y * w - 2 * x * z, sqx - sqy - sqz + sqw)));
+        retVal.x = math::degrees(math::radians(std::asin(2 * test / unit)));
+        retVal.z = math::degrees(math::radians(std::atan2(2 * x * w - 2 * y * z, -sqx + sqy - sqz + sqw)));
       }
 
       return retVal;

--- a/src/math/trig.hpp
+++ b/src/math/trig.hpp
@@ -9,14 +9,50 @@
 
 namespace math
 {
+  namespace {
+    inline float normalize_degrees(float deg) {
+      return deg - std::floor((deg + 180.f) / 360.f) * 360.f;
+    }
+  }
+
   struct radians;
 
   struct degrees
   {
-    explicit degrees (float x) : _ (x) {}
+    explicit degrees (float x) : _ (normalize_degrees(x)) {}
     degrees (radians);
 
     float _;
+
+    inline degrees operator+ (const degrees &v) const
+    {
+      return degrees (_ + v._);
+    }
+
+    inline degrees operator- (const degrees &v) const
+    {
+      return degrees (_ - v._);
+    }
+
+    inline degrees operator-() const
+    {
+      return degrees (-_);
+    }
+
+    inline degrees& operator+= (const degrees &v)
+    {
+      return *this = *this + v;
+    }
+
+    inline degrees& operator-= (const degrees &v)
+    {
+      return *this = *this - v;
+    }
+
+    friend std::ostream& operator<< (std::ostream& os, degrees const& v)
+    {
+      return os << v << "°";
+    }
 
     using vec3 = vector_3d_base<degrees>;
   };
@@ -58,4 +94,14 @@ namespace math
   {
     return radians {std::atan2 (y, x)};
   }
+}
+
+inline math::degrees operator"" _deg (long double v)
+{
+  return math::degrees {static_cast<float> (v)};
+}
+
+inline math::degrees operator"" _deg (unsigned long long int v)
+{
+  return math::degrees {static_cast<float> (v)};
 }

--- a/src/math/vector_3d.hpp
+++ b/src/math/vector_3d.hpp
@@ -25,7 +25,7 @@ namespace math
       };
     };
 
-    vector_3d_base<T>() : vector_3d_base (0.f, 0.f, 0.f) {}
+    vector_3d_base<T>() : vector_3d_base (T(0), T(0), T(0)) {}
     vector_3d_base<T> (T x_, T y_, T z_)
       : x (x_)
       , y (y_)

--- a/src/noggit/MapTile.cpp
+++ b/src/noggit/MapTile.cpp
@@ -768,9 +768,9 @@ void MapTile::saveTile(World* world)
     lMDDF_Data[lID].pos[0] = model.pos.x;
     lMDDF_Data[lID].pos[1] = model.pos.y;
     lMDDF_Data[lID].pos[2] = model.pos.z;
-    lMDDF_Data[lID].rot[0] = model.dir.x;
-    lMDDF_Data[lID].rot[1] = model.dir.y;
-    lMDDF_Data[lID].rot[2] = model.dir.z;
+    lMDDF_Data[lID].rot[0] = model.dir.x._;
+    lMDDF_Data[lID].rot[1] = model.dir.y._;
+    lMDDF_Data[lID].rot[2] = model.dir.z._;
     lMDDF_Data[lID].scale = (uint16_t)(model.scale * 1024);
     lMDDF_Data[lID].flags = 0;
     lID++;
@@ -804,9 +804,9 @@ void MapTile::saveTile(World* world)
     lMODF_Data[lID].pos[0] = object.pos.x;
     lMODF_Data[lID].pos[1] = object.pos.y;
     lMODF_Data[lID].pos[2] = object.pos.z;
-    lMODF_Data[lID].rot[0] = object.dir.x;
-    lMODF_Data[lID].rot[1] = object.dir.y;
-    lMODF_Data[lID].rot[2] = object.dir.z;
+    lMODF_Data[lID].rot[0] = object.dir.x._;
+    lMODF_Data[lID].rot[1] = object.dir.y._;
+    lMODF_Data[lID].rot[2] = object.dir.z._;
 
     lMODF_Data[lID].extents[0][0] = object.extents[0].x;
     lMODF_Data[lID].extents[0][1] = object.extents[0].y;

--- a/src/noggit/Misc.cpp
+++ b/src/noggit/Misc.cpp
@@ -172,6 +172,11 @@ namespace misc
   {
     return float_equals(v1.x, v2.x) && float_equals(v1.y, v2.y) && float_equals(v1.z, v2.z);
   }
+
+  bool deg_vec3d_equals(math::degrees::vec3 const& v1, math::degrees::vec3 const& v2)
+  {
+    return float_equals(v1.x._, v2.x._) && float_equals(v1.y._, v2.y._) && float_equals(v1.z._, v2.z._);
+  }
 }
 
 void SetChunkHeader(sExtendableArray& pArray, int pPosition, int pMagix, int pSize)

--- a/src/noggit/Misc.h
+++ b/src/noggit/Misc.h
@@ -46,6 +46,7 @@ namespace misc
   }
 
   bool vec3d_equals(math::vector_3d const& v1, math::vector_3d const& v2);
+  bool deg_vec3d_equals(math::degrees::vec3 const& v1, math::degrees::vec3 const& v2);
 
   inline int rounded_int_div(int value, int div)
   {

--- a/src/noggit/ModelInstance.cpp
+++ b/src/noggit/ModelInstance.cpp
@@ -21,7 +21,10 @@ ModelInstance::ModelInstance(std::string const& filename, ENTRY_MDDF const*d)
 {
 	uid = d->uniqueID;
 	pos = math::vector_3d(d->pos[0], d->pos[1], d->pos[2]);
-	dir = math::vector_3d(d->rot[0], d->rot[1], d->rot[2]);
+	dir = math::degrees::vec3( math::degrees(d->rot[0])
+                           , math::degrees(d->rot[1])
+                           , math::degrees(d->rot[2])
+                           );
 	// scale factor - divide by 1024. blizzard devs must be on crack, why not just use a float?
 	scale = d->scale / 1024.0f;
 
@@ -39,7 +42,7 @@ bool ModelInstance::is_a_duplicate_of(ModelInstance const& other)
 {
   return model->filename == other.model->filename
       && misc::vec3d_equals(pos, other.pos)
-      && misc::vec3d_equals(dir, other.dir)
+      && misc::deg_vec3d_equals(dir, other.dir)
       && misc::float_equals(scale, other.scale);
 }
 
@@ -93,9 +96,9 @@ void ModelInstance::update_transform_matrix()
 {
   math::matrix_4x4 mat (math::matrix_4x4 (math::matrix_4x4::translation, pos)
           * math::matrix_4x4 (math::matrix_4x4::rotation_yzx
-                              , { math::degrees (-dir.z)
-                              , math::degrees (dir.y - 90.0f)
-                              , math::degrees (dir.x)
+                              , { -dir.z
+                              , dir.y - 90.0_deg
+                              , dir.x
                               }
           )
           * math::matrix_4x4 (math::matrix_4x4::scale, scale)
@@ -130,9 +133,9 @@ void ModelInstance::intersect ( math::matrix_4x4 const& model_view
 }
 
 void ModelInstance::resetDirection(){
-  dir.x = 0;
+  dir.x = 0_deg;
   //dir.y=0; only reset incline
-  dir.z = 0;
+  dir.z = 0_deg;
 }
 
 bool ModelInstance::isInsideRect(math::vector_3d rect[2]) const

--- a/src/noggit/ModelInstance.h
+++ b/src/noggit/ModelInstance.h
@@ -25,7 +25,7 @@ public:
   scoped_model_reference model;
 
   math::vector_3d pos;
-  math::vector_3d dir;
+  math::degrees::vec3 dir;
   math::vector_3d light_color = { 1.f, 1.f, 1.f };
 
   //! \todo  Get this out and do somehow else.

--- a/src/noggit/WMOInstance.cpp
+++ b/src/noggit/WMOInstance.cpp
@@ -13,7 +13,7 @@
 WMOInstance::WMOInstance(std::string const& filename, ENTRY_MODF const* d)
   : wmo(filename)
   , pos(math::vector_3d(d->pos[0], d->pos[1], d->pos[2]))
-  , dir(math::vector_3d(d->rot[0], d->rot[1], d->rot[2]))
+  , dir(math::degrees(d->rot[0]), math::degrees(d->rot[1]), math::degrees(d->rot[2]))
   , mUniqueID(d->uniqueID), mFlags(d->flags)
   , mUnknown(d->unknown), mNameset(d->nameSet)
   , _doodadset(d->doodadSet)
@@ -28,7 +28,7 @@ WMOInstance::WMOInstance(std::string const& filename, ENTRY_MODF const* d)
 WMOInstance::WMOInstance(std::string const& filename)
   : wmo(filename)
   , pos(math::vector_3d(0.0f, 0.0f, 0.0f))
-  , dir(math::vector_3d(0.0f, 0.0f, 0.0f))
+  , dir(math::degrees::vec3(0_deg, 0_deg, 0_deg))
   , mUniqueID(0)
   , mFlags(0)
   , mUnknown(0)
@@ -42,7 +42,7 @@ bool WMOInstance::is_a_duplicate_of(WMOInstance const& other)
 {
   return wmo->filename == other.wmo->filename
       && misc::vec3d_equals(pos, other.pos)
-      && misc::vec3d_equals(dir, other.dir);
+      && misc::deg_vec3d_equals(dir, other.dir);
 }
 
 void WMOInstance::draw ( opengl::scoped::use_program& wmo_shader
@@ -106,9 +106,9 @@ void WMOInstance::update_transform_matrix()
   math::matrix_4x4 mat( math::matrix_4x4(math::matrix_4x4::translation, pos)
                       * math::matrix_4x4
                         ( math::matrix_4x4::rotation_yzx
-                        , { math::degrees(-dir.z)
-                          , math::degrees(dir.y - 90.0f)
-                          , math::degrees(dir.x)
+                        , { -dir.z
+                          , dir.y - 90_deg
+                          , dir.x
                           }
                         )
                       );
@@ -217,7 +217,7 @@ void WMOInstance::update_doodads()
 
 void WMOInstance::resetDirection()
 {
-  dir = math::vector_3d(0.0f, dir.y, 0.0f);
+  dir = math::degrees::vec3(0.0_deg, dir.y, 0.0_deg);
   recalcExtents();
 }
 

--- a/src/noggit/WMOInstance.h
+++ b/src/noggit/WMOInstance.h
@@ -19,7 +19,7 @@ public:
   math::vector_3d pos;
   math::vector_3d  extents[2];
   std::map<int, std::pair<math::vector_3d, math::vector_3d>> group_extents;
-  math::vector_3d  dir;
+  math::degrees::vec3  dir;
   unsigned int mUniqueID;
   uint16_t mFlags;
   uint16_t mUnknown;

--- a/src/noggit/World.cpp
+++ b/src/noggit/World.cpp
@@ -472,7 +472,7 @@ void World::set_selected_models_pos(math::vector_3d const& pos, bool change_heig
 
 void World::rotate_selected_models(math::degrees rx, math::degrees ry, math::degrees rz, bool use_pivot)
 {
-  math::vector_3d dir_change(rx._, ry._, rz._);
+  math::degrees::vec3 dir_change(rx, ry, rz);
   bool has_multi_select = has_multiple_model_selected();
 
   for (auto& entry : _current_selection)
@@ -500,7 +500,7 @@ void World::rotate_selected_models(math::degrees rx, math::degrees ry, math::deg
       pos += rot_result - diff_pos;
     }
 
-    math::vector_3d& dir = entry_is_m2
+    math::degrees::vec3& dir = entry_is_m2
         ? boost::get<selected_model_type>(entry)->dir
         : boost::get<selected_wmo_type>(entry)->dir
         ;
@@ -534,7 +534,7 @@ void World::rotate_selected_models_randomly(float minX, float maxX, float minY, 
 
     updateTilesEntry(entry, model_update::remove);
 
-    math::vector_3d& dir = entry_is_m2
+    math::degrees::vec3& dir = entry_is_m2
       ? boost::get<selected_model_type>(entry)->dir
       : boost::get<selected_wmo_type>(entry)->dir
       ;
@@ -565,7 +565,7 @@ void World::rotate_selected_models_randomly(float minX, float maxX, float minY, 
 
 void World::set_selected_models_rotation(math::degrees rx, math::degrees ry, math::degrees rz)
 {
-  math::vector_3d new_dir(rx._, ry._, rz._);
+  math::degrees::vec3 new_dir(rx, ry, rz);
 
   for (auto& entry : _current_selection)
   {
@@ -579,7 +579,7 @@ void World::set_selected_models_rotation(math::degrees rx, math::degrees ry, mat
 
     updateTilesEntry(entry, model_update::remove);
 
-    math::vector_3d& dir = entry_is_m2
+    math::degrees::vec3& dir = entry_is_m2
       ? boost::get<selected_model_type>(entry)->dir
       : boost::get<selected_wmo_type>(entry)->dir
       ;
@@ -641,7 +641,7 @@ void World::rotate_selected_models_to_ground_normal(bool smoothNormals)
       : boost::get<selected_wmo_type>(entry)->pos
       ;
 
-    math::vector_3d& dir = entry_is_m2
+    math::degrees::vec3& dir = entry_is_m2
       ? boost::get<selected_model_type>(entry)->dir
       : boost::get<selected_wmo_type>(entry)->dir
       ;
@@ -1959,7 +1959,7 @@ void World::unload_every_model_and_wmo_instance()
 void World::addM2 ( std::string const& filename
                   , math::vector_3d newPos
                   , float scale
-                  , math::vector_3d rotation
+                  , math::degrees::vec3 rotation
                   , noggit::object_paste_params* paste_params
                   )
 {
@@ -1974,15 +1974,15 @@ void World::addM2 ( std::string const& filename
   {
     float min = paste_params->minRotation;
     float max = paste_params->maxRotation;
-    model_instance.dir.y += misc::randfloat(min, max);
+    model_instance.dir.y += math::degrees(misc::randfloat(min, max));
   }
 
   if (_settings->value ("model/random_tilt", false).toBool ())
   {
     float min = paste_params->minTilt;
     float max = paste_params->maxTilt;
-    model_instance.dir.x += misc::randfloat(min, max);
-    model_instance.dir.z += misc::randfloat(min, max);
+    model_instance.dir.x += math::degrees(misc::randfloat(min, max));
+    model_instance.dir.z += math::degrees(misc::randfloat(min, max));
   }
 
   if (_settings->value ("model/random_size", false).toBool ())
@@ -2003,7 +2003,7 @@ void World::addM2 ( std::string const& filename
 
 void World::addWMO ( std::string const& filename
                    , math::vector_3d newPos
-                   , math::vector_3d rotation
+                   , math::degrees::vec3 rotation
                    )
 {
   WMOInstance wmo_instance(filename);

--- a/src/noggit/World.cpp
+++ b/src/noggit/World.cpp
@@ -722,7 +722,6 @@ void World::rotate_selected_models_to_ground_normal(bool smoothNormals)
                     + (worldUp * varnormal));
     q.normalize();
 
-    math::vector_3d new_dir;
     // To euler, because wow
     dir = q.ToEulerAngles();
 

--- a/src/noggit/World.h
+++ b/src/noggit/World.h
@@ -239,12 +239,12 @@ public:
 
   void addM2 ( std::string const& filename
              , math::vector_3d newPos
-             , float scale, math::vector_3d rotation
+             , float scale, math::degrees::vec3 rotation
              , noggit::object_paste_params*
              );
   void addWMO ( std::string const& filename
               , math::vector_3d newPos
-              , math::vector_3d rotation
+              , math::degrees::vec3 rotation
               );
 
   // add a m2 instance to the world (needs to be positioned already), return the uid

--- a/src/noggit/ui/ObjectEditor.cpp
+++ b/src/noggit/ui/ObjectEditor.cpp
@@ -433,7 +433,7 @@ namespace noggit
         if (selection.which() == eEntry_Model)
         {
           float scale(1.f);
-          math::vector_3d rotation(0.f, 0.f, 0.f);
+          math::degrees::vec3 rotation(0_deg, 0_deg, 0_deg);
 
           if (_copy_model_stats)
           {
@@ -451,7 +451,7 @@ namespace noggit
         }
         else if (selection.which() == eEntry_WMO)
         {
-          math::vector_3d rotation(0.f, 0.f, 0.f);
+          math::degrees::vec3 rotation(0.0_deg, 0.0_deg, 0.0_deg);
           if (_copy_model_stats)
           {
             // copy rot from original model. Dirty but working

--- a/src/noggit/ui/RotationEditor.cpp
+++ b/src/noggit/ui/RotationEditor.cpp
@@ -44,15 +44,15 @@ namespace noggit
       layout->addRow(new QLabel("- rotation and scale only\n  change when pressing enter", this));
       layout->addRow(new QLabel("- scaling is multiplicative", this));
 
-      _rotation_x->setRange (-1800.f, 1800.f);
+      _rotation_x->setRange (-180.f, 180.f);
       _rotation_x->setDecimals (3);
       _rotation_x->setWrapping(true);
       _rotation_x->setSingleStep(5.0f);
-      _rotation_z->setRange (-1800.f, 1800.f);
+      _rotation_z->setRange (-180.f, 180.f);
       _rotation_z->setDecimals (3);
       _rotation_z->setWrapping(true);
       _rotation_z->setSingleStep(5.0f);
-      _rotation_y->setRange (-1800.f, 3600.f);
+      _rotation_y->setRange (-180.f, 180.f);
       _rotation_y->setDecimals (3);
       _rotation_y->setWrapping(true);
       _rotation_y->setSingleStep(5.0f);

--- a/src/noggit/ui/RotationEditor.cpp
+++ b/src/noggit/ui/RotationEditor.cpp
@@ -227,9 +227,9 @@ namespace noggit
             _position_x->setValue(model->pos.x);
             _position_y->setValue(model->pos.y);
             _position_z->setValue(model->pos.z);
-            _rotation_x->setValue(model->dir.x);
-            _rotation_y->setValue(model->dir.y);
-            _rotation_z->setValue(model->dir.z);
+            _rotation_x->setValue(model->dir.x._);
+            _rotation_y->setValue(model->dir.y._);
+            _rotation_z->setValue(model->dir.z._);
             _scale->setValue(model->scale);
 
             _scale->setEnabled(true);
@@ -240,9 +240,9 @@ namespace noggit
             _position_x->setValue(wmo->pos.x);
             _position_y->setValue(wmo->pos.y);
             _position_z->setValue(wmo->pos.z);
-            _rotation_x->setValue(wmo->dir.x);
-            _rotation_y->setValue(wmo->dir.y);
-            _rotation_z->setValue(wmo->dir.z);
+            _rotation_x->setValue(wmo->dir.x._);
+            _rotation_y->setValue(wmo->dir.y._);
+            _rotation_z->setValue(wmo->dir.z._);
 
             _scale->setValue(1.f);
             _scale->setEnabled(false);

--- a/test/math/trig.cpp
+++ b/test/math/trig.cpp
@@ -4,19 +4,25 @@
 
 namespace math
 {
-  BOOST_AUTO_TEST_CASE (radians_and_degrees_are_trivial_wrappers)
+  BOOST_AUTO_TEST_CASE (radians_is_a_trivial_wrapper)
   {
     BOOST_CHECK_EQUAL (radians (10020)._, 10020);
-    BOOST_CHECK_EQUAL (degrees (10020)._, 10020);
+  }
+
+  BOOST_AUTO_TEST_CASE (degrees_wraps_values)
+  {
+    BOOST_CHECK_EQUAL (degrees (10020)._, -60);
   }
 
   BOOST_AUTO_TEST_CASE (deg_to_rad)
   {
-    BOOST_CHECK_CLOSE (radians (degrees (0.000f))._, 0.0f * constants::pi, 0.0001f);
-    BOOST_CHECK_CLOSE (radians (degrees (90.00f))._, 0.5f * constants::pi, 0.0001f);
-    BOOST_CHECK_CLOSE (radians (degrees (180.0f))._, 1.0f * constants::pi, 0.0001f);
-    BOOST_CHECK_CLOSE (radians (degrees (270.0f))._, 1.5f * constants::pi, 0.0001f);
-    BOOST_CHECK_CLOSE (radians (degrees (360.0f))._, 2.0f * constants::pi, 0.0001f);
+    BOOST_CHECK_CLOSE (radians (degrees (-180.0f))._, -1.0f * constants::pi, 0.0001f);
+    BOOST_CHECK_CLOSE (radians (degrees (-90.00f))._, -0.5f * constants::pi, 0.0001f);
+    BOOST_CHECK_CLOSE (radians (degrees (0.000f))._,   0.0f * constants::pi, 0.0001f);
+    BOOST_CHECK_CLOSE (radians (degrees (90.00f))._,   0.5f * constants::pi, 0.0001f);
+    BOOST_CHECK_CLOSE (radians (degrees (180.0f))._,  -1.0f * constants::pi, 0.0001f);
+    BOOST_CHECK_CLOSE (radians (degrees (270.0f))._,  -0.5f * constants::pi, 0.0001f);
+    BOOST_CHECK_CLOSE (radians (degrees (360.0f))._,   0.0f * constants::pi, 0.0001f);
   }
 
   BOOST_AUTO_TEST_CASE (rad_to_deg)


### PR DESCRIPTION
adds arithmetic functions required to use a vector of `math::degrees` to store model rotations normalized to [-180,180)
picks up on #74

todo:
- [x] fix the interface limits