### PR TITLE
(Possible) Fix for strength save bug

### DIFF
--- a/src/noggit/texture_set.cpp
+++ b/src/noggit/texture_set.cpp
@@ -416,6 +416,7 @@ bool TextureSet::paintTexture(float xbase, float zbase, float x, float z, Brush*
 
         if (!misc::float_equals(current_alpha, strength))
         {
+          float totOthers = 0.0f;
           for (int layer = 0; layer < nTextures; ++layer)
           {
             if (layer == tex_layer)
@@ -425,11 +426,23 @@ bool TextureSet::paintTexture(float xbase, float zbase, float x, float z, Brush*
             else
             {
               amaps[layer][offset] -= alpha_change * (amaps[layer][offset] / sum_other_alphas);
+
             }
+
+            if (amaps[layer][offset] > 1.0f)
+                amaps[layer][offset] = 1.0f;
+            else if (amaps[layer][offset] < 0.0f || isnan(amaps[layer][offset]))
+                    amaps[layer][offset] = 0.0f;
+
+            if(layer != 0)
+                totOthers += amaps[layer][offset];
           }
+
+          amaps[0][offset] = std::max(0.0f, std::min(1.0f - totOthers, 1.0f));
 
           changed = true;
         }
+
       }
 
       xPos += TEXDETAILSIZE;


### PR DESCRIPTION
https://youtu.be/cCoSve4mS2w
As of the video above, sometimes when using a strength below max, saving will cause weird dots around the opacity.
It seems that it is generally caused by the paintTexture function being able to create situations where the layers don't sum up to 1, and a divide by zero sometimes causing a -nan that also messes with the math. 
I've changed to check cases where painting would go beyond possible values, as well as ensuring that ground layer is always 1 - sumofotherlayers, as that's how the ADT assumes it works.

This should hopefully fix most of those cases.