### PR TITLE
extendable array: prevent use after extend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -284,6 +284,7 @@ endif()
 
 set ( util_sources
       src/util/exception_to_string.cpp
+      src/util/sExtendableArray.cpp
     )
 
 set ( noggit_root_headers

--- a/src/noggit/ChunkWater.cpp
+++ b/src/noggit/ChunkWater.cpp
@@ -97,7 +97,7 @@ void ChunkWater::fromFile(MPQFile &f, size_t basePos)
 }
 
 
-void ChunkWater::save(sExtendableArray& adt, int base_pos, int& header_pos, int& current_pos)
+void ChunkWater::save(util::sExtendableArray& adt, int base_pos, int& header_pos, int& current_pos)
 {
   MH2O_Header header;
 

--- a/src/noggit/ChunkWater.cpp
+++ b/src/noggit/ChunkWater.cpp
@@ -125,7 +125,7 @@ void ChunkWater::save(sExtendableArray& adt, int base_pos, int& header_pos, int&
     }
   }
 
-  memcpy(adt.GetPointer<char>(header_pos), &header, sizeof(MH2O_Header));
+  memcpy(adt.GetPointer<char>(header_pos).get(), &header, sizeof(MH2O_Header));
   header_pos += sizeof(MH2O_Header);
 }
 

--- a/src/noggit/ChunkWater.hpp
+++ b/src/noggit/ChunkWater.hpp
@@ -7,12 +7,12 @@
 #include <noggit/liquid_layer.hpp>
 #include <noggit/MapHeaders.h>
 #include <noggit/tool_enums.hpp>
+#include <util/sExtendableArray.hpp>
 
 #include <vector>
 #include <set>
 
 class MPQFile;
-class sExtendableArray;
 class MapChunk;
 
 class ChunkWater
@@ -28,7 +28,7 @@ public:
 
   void from_mclq(std::vector<mclq>& layers);
   void fromFile(MPQFile &f, size_t basePos);
-  void save(sExtendableArray& adt, int base_pos, int& header_pos, int& current_pos);
+  void save(util::sExtendableArray& adt, int base_pos, int& header_pos, int& current_pos);
 
   void draw ( math::frustum const& frustum
             , const float& cull_distance

--- a/src/noggit/MapChunk.cpp
+++ b/src/noggit/MapChunk.cpp
@@ -1134,7 +1134,7 @@ void MapChunk::setFlag(bool changeto, uint32_t flag)
   }
 }
 
-void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCIN_Position, std::map<std::string, int> &lTextures, std::vector<WMOInstance> &lObjectInstances, std::vector<ModelInstance>& lModelInstances)
+void MapChunk::save(util::sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCIN_Position, std::map<std::string, int> &lTextures, std::vector<WMOInstance> &lObjectInstances, std::vector<ModelInstance>& lModelInstances)
 {
   int lID;
   int lMCNK_Size = 0x80;

--- a/src/noggit/MapChunk.cpp
+++ b/src/noggit/MapChunk.cpp
@@ -1145,7 +1145,7 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
 
                                                                                                    // MCNK data
   lADTFile.Insert(lCurrentPosition + 8, 0x80, reinterpret_cast<char*>(&(header)));
-  MapChunkHeader *lMCNK_header = lADTFile.GetPointer<MapChunkHeader>(lCurrentPosition + 8);
+  auto const lMCNK_header = lADTFile.GetPointer<MapChunkHeader>(lCurrentPosition + 8);
 
   header_flags.flags.do_not_fix_alpha_map = 1;
 
@@ -1200,7 +1200,7 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
 
   lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->ofsHeight = lCurrentPosition - lMCNK_Position;
 
-  float* lHeightmap = lADTFile.GetPointer<float>(lCurrentPosition + 8);
+  auto const lHeightmap = lADTFile.GetPointer<float>(lCurrentPosition + 8);
 
   for (int i = 0; i < mapbufsize; ++i)
     lHeightmap[i] = mVertices[i].y - mVertices[0].y;
@@ -1217,13 +1217,13 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
     SetChunkHeader(lADTFile, lCurrentPosition, 'MCCV', lMCCV_Size);
     lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->ofsMCCV = lCurrentPosition - lMCNK_Position;
 
-    unsigned int *lmccv = lADTFile.GetPointer<unsigned int>(lCurrentPosition + 8);
+    auto const lmccv = lADTFile.GetPointer<unsigned int>(lCurrentPosition + 8);
 
     for (int i = 0; i < mapbufsize; ++i)
     {
-      *lmccv++ = ((unsigned char)(mccv[i].z * 127.0f) & 0xFF)
-        + (((unsigned char)(mccv[i].y * 127.0f) & 0xFF) << 8)
-        + (((unsigned char)(mccv[i].x * 127.0f) & 0xFF) << 16);
+      lmccv[i] = (((unsigned char)(mccv[i].z * 127.0f) & 0xFF) <<  0)
+               + (((unsigned char)(mccv[i].y * 127.0f) & 0xFF) <<  8)
+               + (((unsigned char)(mccv[i].x * 127.0f) & 0xFF) << 16);
     }
 
     lCurrentPosition += 8 + lMCCV_Size;
@@ -1242,7 +1242,7 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
 
   lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->ofsNormal = lCurrentPosition - lMCNK_Position;
 
-  char * lNormals = lADTFile.GetPointer<char>(lCurrentPosition + 8);
+  auto const lNormals = lADTFile.GetPointer<char>(lCurrentPosition + 8);
 
   for (int i = 0; i < mapbufsize; ++i)
   {
@@ -1279,7 +1279,7 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
   // MCLY data
   for (size_t j = 0; j < texture_set->num(); ++j)
   {
-    ENTRY_MCLY * lLayer = lADTFile.GetPointer<ENTRY_MCLY>(lCurrentPosition + 8 + 0x10 * j);
+    auto const lLayer = lADTFile.GetPointer<ENTRY_MCLY>(lCurrentPosition + 8 + 0x10 * j);
 
     lLayer->textureID = lTextures.find(texture_set->filename(j))->second;
     lLayer->flags = texture_set->flag(j);
@@ -1345,7 +1345,7 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
   lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->nMapObjRefs = lObjectIDs.size();
 
   // MCRF data
-  int *lReferences = lADTFile.GetPointer<int>(lCurrentPosition + 8);
+  auto const lReferences = lADTFile.GetPointer<int>(lCurrentPosition + 8);
 
   lID = 0;
   for (std::list<int>::iterator it = lDoodadIDs.begin(); it != lDoodadIDs.end(); ++it)
@@ -1376,10 +1376,10 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
     lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->ofsShadow = lCurrentPosition - lMCNK_Position;
     lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->sizeShadow = 0x200;
 
-    char * lLayer = lADTFile.GetPointer<char>(lCurrentPosition + 8);
+    auto const lLayer = lADTFile.GetPointer<char>(lCurrentPosition + 8);
 
     auto shadow_map = compressed_shadow_map();
-    memcpy(lLayer, shadow_map.data(), 0x200);
+    memcpy(lLayer.get(), shadow_map.data(), 0x200);
 
     lCurrentPosition += 8 + lMCSH_Size;
     lMCNK_Size += 8 + lMCSH_Size;
@@ -1398,11 +1398,11 @@ void MapChunk::save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCI
   lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->ofsAlpha = lCurrentPosition - lMCNK_Position;
   lADTFile.GetPointer<MapChunkHeader>(lMCNK_Position + 8)->sizeAlpha = 8 + lMCAL_Size;
 
-  char * lAlphaMaps = lADTFile.GetPointer<char>(lCurrentPosition + 8);
+  auto lAlphaMaps = lADTFile.GetPointer<char>(lCurrentPosition + 8);
 
   for (auto alpha : alphamaps)
   {
-    memcpy(lAlphaMaps, alpha.data(), alpha.size());
+    memcpy(lAlphaMaps.get(), alpha.data(), alpha.size());
     lAlphaMaps += alpha.size();
   }
 

--- a/src/noggit/MapChunk.h
+++ b/src/noggit/MapChunk.h
@@ -3,17 +3,18 @@
 #pragma once
 
 #include <math/quaternion.hpp> // math::vector_4d
-#include <noggit/map_enums.hpp>
 #include <noggit/MapTile.h> // MapTile
+#include <noggit/Misc.h>
 #include <noggit/ModelInstance.h>
 #include <noggit/Selection.h>
 #include <noggit/TextureManager.h>
 #include <noggit/WMOInstance.h>
+#include <noggit/map_enums.hpp>
 #include <noggit/texture_set.hpp>
 #include <noggit/tool_enums.hpp>
 #include <opengl/scoped.hpp>
 #include <opengl/texture.hpp>
-#include <noggit/Misc.h>
+#include <util/sExtendableArray.hpp>
 
 #include <map>
 #include <memory>
@@ -26,7 +27,6 @@ namespace math
 }
 class Brush;
 class ChunkWater;
-class sExtendableArray;
 
 using StripType = uint16_t;
 static const int mapbufsize = 9 * 9 + 8 * 8; // chunk size
@@ -194,7 +194,7 @@ public:
   void clearHeight();
 
   //! \todo this is ugly create a build struct or sth
-  void save(sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCIN_Position, std::map<std::string, int> &lTextures, std::vector<WMOInstance> &lObjectInstances, std::vector<ModelInstance>& lModelInstances);
+  void save(util::sExtendableArray &lADTFile, int &lCurrentPosition, int &lMCIN_Position, std::map<std::string, int> &lTextures, std::vector<WMOInstance> &lObjectInstances, std::vector<ModelInstance>& lModelInstances);
 
   // fix the gaps with the chunk to the left
   bool fixGapLeft(const MapChunk* chunk);

--- a/src/noggit/MapTile.cpp
+++ b/src/noggit/MapTile.cpp
@@ -910,14 +910,11 @@ void MapTile::saveTile(World* world)
   }
 #endif
 
-  // \todo This sounds wrong. Not that it is named allocate, but that
-  // the fact that there *are* unused nulls.
-  lADTFile.Allocate(lCurrentPosition); // cleaning unused nulls at the end of file
-
-
   {
     MPQFile f(filename);
-    f.setBuffer(lADTFile.all_data());
+    // \todo This sounds wrong. There shouldn't *be* unused nulls to
+    // begin with.
+    f.setBuffer(lADTFile.data_up_to (lCurrentPosition)); // cleaning unused nulls at the end of file
     f.SaveFile();
   }
 

--- a/src/noggit/MapTile.cpp
+++ b/src/noggit/MapTile.cpp
@@ -14,6 +14,7 @@
 #include <noggit/texture_set.hpp>
 #include <opengl/scoped.hpp>
 #include <opengl/shader.hpp>
+#include <util/sExtendableArray.hpp>
 
 #include <QtCore/QSettings>
 
@@ -645,7 +646,7 @@ void MapTile::saveTile(World* world)
     texture.second = lID++;
 
   // Now write the file.
-  sExtendableArray lADTFile;
+  util::sExtendableArray lADTFile;
 
   int lCurrentPosition = 0;
 
@@ -909,12 +910,14 @@ void MapTile::saveTile(World* world)
   }
 #endif
 
-  lADTFile.Extend(lCurrentPosition - lADTFile.data.size()); // cleaning unused nulls at the end of file
+  // \todo This sounds wrong. Not that it is named allocate, but that
+  // the fact that there *are* unused nulls.
+  lADTFile.Allocate(lCurrentPosition); // cleaning unused nulls at the end of file
 
 
   {
     MPQFile f(filename);
-    f.setBuffer(lADTFile.data);
+    f.setBuffer(lADTFile.all_data());
     f.SaveFile();
   }
 

--- a/src/noggit/MapTile.cpp
+++ b/src/noggit/MapTile.cpp
@@ -721,7 +721,7 @@ void MapTile::saveTile(World* world)
 
   // MMID data
   // WMO model names
-  int * lMMID_Data = lADTFile.GetPointer<int>(lCurrentPosition + 8);
+  auto const lMMID_Data = lADTFile.GetPointer<int>(lCurrentPosition + 8);
 
   lID = 0;
   for (auto const& model : lModels)
@@ -756,7 +756,7 @@ void MapTile::saveTile(World* world)
   lADTFile.GetPointer<MHDR>(lMHDR_Position + 8)->mwid = lCurrentPosition - 0x14;
 
   // MWID data
-  int * lMWID_Data = lADTFile.GetPointer<int>(lCurrentPosition + 8);
+  auto const lMWID_Data = lADTFile.GetPointer<int>(lCurrentPosition + 8);
 
   lID = 0;
   for (auto const& object : lObjects)
@@ -771,7 +771,7 @@ void MapTile::saveTile(World* world)
   lADTFile.GetPointer<MHDR>(lMHDR_Position + 8)->mddf = lCurrentPosition - 0x14;
 
   // MDDF data
-  ENTRY_MDDF* lMDDF_Data = lADTFile.GetPointer<ENTRY_MDDF>(lCurrentPosition + 8);
+  auto const lMDDF_Data = lADTFile.GetPointer<ENTRY_MDDF>(lCurrentPosition + 8);
 
   if(world->mapIndex.sort_models_by_size_class())
   {
@@ -815,7 +815,7 @@ void MapTile::saveTile(World* world)
   lADTFile.GetPointer<MHDR>(lMHDR_Position + 8)->modf = lCurrentPosition - 0x14;
 
   // MODF data
-  ENTRY_MODF *lMODF_Data = lADTFile.GetPointer<ENTRY_MODF>(lCurrentPosition + 8);
+  auto const lMODF_Data = lADTFile.GetPointer<ENTRY_MODF>(lCurrentPosition + 8);
 
   lID = 0;
   for (auto const& object : lObjectInstances)
@@ -875,7 +875,7 @@ void MapTile::saveTile(World* world)
     SetChunkHeader(lADTFile, lCurrentPosition, 'MFBO', chunkSize);
     lADTFile.GetPointer<MHDR>(lMHDR_Position + 8)->mfbo = lCurrentPosition - 0x14;
 
-    int16_t *lMFBO_Data = lADTFile.GetPointer<int16_t>(lCurrentPosition + 8);
+    auto const lMFBO_Data = lADTFile.GetPointer<int16_t>(lCurrentPosition + 8);
 
     lID = 0;
 
@@ -896,7 +896,7 @@ void MapTile::saveTile(World* world)
     SetChunkHeader(lADTFile, lCurrentPosition, 'MTFX', 4 * mTextureEffects.size());
     lADTFile.GetPointer<MHDR>(lMHDR_Position + 8)->mtfx = lCurrentPosition - 0x14;
 
-    uint32_t* lMTFX_Data = lADTFile.GetPointer<uint32_t>(lCurrentPosition + 8);
+    auto const lMTFX_Data = lADTFile.GetPointer<uint32_t>(lCurrentPosition + 8);
 
     lID = 0;
     //they should be in the correct order...

--- a/src/noggit/Misc.cpp
+++ b/src/noggit/Misc.cpp
@@ -179,7 +179,7 @@ namespace misc
   }
 }
 
-void SetChunkHeader(sExtendableArray& pArray, int pPosition, int pMagix, int pSize)
+void SetChunkHeader(util::sExtendableArray& pArray, int pPosition, int pMagix, int pSize)
 {
   auto const Header = pArray.GetPointer<sChunkHeader>(pPosition);
   Header->mMagic = pMagix;

--- a/src/noggit/Misc.cpp
+++ b/src/noggit/Misc.cpp
@@ -181,7 +181,7 @@ namespace misc
 
 void SetChunkHeader(sExtendableArray& pArray, int pPosition, int pMagix, int pSize)
 {
-  sChunkHeader* Header = pArray.GetPointer<sChunkHeader>(pPosition);
+  auto const Header = pArray.GetPointer<sChunkHeader>(pPosition);
   Header->mMagic = pMagix;
   Header->mSize = pSize;
 }

--- a/src/noggit/Misc.h
+++ b/src/noggit/Misc.h
@@ -7,6 +7,7 @@
 #include <math/vector_3d.hpp>
 #include <math/vector_4d.hpp>
 #include <noggit/Log.h>
+#include <util/sExtendableArray.hpp>
 
 #include <algorithm>
 #include <cassert>
@@ -108,96 +109,13 @@ namespace misc
 
 //! \todo collect all lose functions/classes/structs for now, sort them later
 
-class sExtendableArray
-{
-public:
-  std::vector<char> data;
-
-	void Allocate (unsigned long pSize)
-	{
-    data.resize (pSize);
-	}
-
-	void Extend (long pAddition)
-	{
-    data.resize (data.size() + pAddition);
-	}
-
-  void Insert (unsigned long pPosition, unsigned long pAddition)
-	{
-    std::vector<char> tmp (pAddition);
-    data.insert (data.begin() + pPosition, tmp.begin(), tmp.end());
-  }
-
-	void Insert (unsigned long pPosition, unsigned long pAddition, const char * pAdditionalData)
-	{
-    data.insert (data.begin() + pPosition, pAdditionalData, pAdditionalData + pAddition);
-	}
-
-  template<typename T>
-    struct LazyPointer
-  {
-    std::vector<char>& _data;
-    std::size_t _position;
-    LazyPointer (std::vector<char>& data, std::size_t position);
-    T* get() const;
-    T& operator*() const;
-    T* operator->() const;
-    T& operator[] (std::size_t) const;
-    LazyPointer<T>& operator+= (std::size_t);
-  };
-
-	template<typename To>
-	LazyPointer<To> GetPointer(unsigned long pPosition = 0)
-	{
-    return {data, pPosition};
-	}
-
-  sExtendableArray() = default;
-	sExtendableArray(unsigned long pSize, const char *pData)
-    : data (pData, pData + pSize)
-	{}
-};
-
 struct sChunkHeader
 {
   int mMagic;
   int mSize;
 };
 
-void SetChunkHeader(sExtendableArray& pArray, int pPosition, int pMagix, int pSize = 0);
+void SetChunkHeader(util::sExtendableArray& pArray, int pPosition, int pMagix, int pSize = 0);
 
 bool pointInside(math::vector_3d point, math::vector_3d extents[2]);
 void minmax(math::vector_3d* a, math::vector_3d* b);
-
-template<typename T>
-  sExtendableArray::LazyPointer<T>::LazyPointer (std::vector<char>& data, std::size_t position)
-  : _data (data)
-  , _position (position)
-{}
-template<typename T>
-  T* sExtendableArray::LazyPointer<T>::get() const
-{
-  return reinterpret_cast<T*> (_data.data() + _position);
-}
-template<typename T>
-  T& sExtendableArray::LazyPointer<T>::operator*() const
-{
-  return *get();
-}
-template<typename T>
-  T* sExtendableArray::LazyPointer<T>::operator->() const
-{
-  return get();
-}
-template<typename T>
-T& sExtendableArray::LazyPointer<T>::operator[] (std::size_t i) const
-{
-  return *(get() + i);
-}
-template<typename T>
-sExtendableArray::LazyPointer<T>& sExtendableArray::LazyPointer<T>::operator+= (std::size_t num)
-{
-  _position += num * sizeof (T);
-  return *this;
-}

--- a/src/noggit/TileWater.cpp
+++ b/src/noggit/TileWater.cpp
@@ -77,7 +77,7 @@ void TileWater::autoGen(float factor)
   }
 }
 
-void TileWater::saveToFile(sExtendableArray &lADTFile, int &lMHDR_Position, int &lCurrentPosition)
+void TileWater::saveToFile(util::sExtendableArray &lADTFile, int &lMHDR_Position, int &lCurrentPosition)
 {
   if (!hasData(0))
   {

--- a/src/noggit/TileWater.hpp
+++ b/src/noggit/TileWater.hpp
@@ -7,11 +7,11 @@
 #include <noggit/MPQ.h>
 #include <noggit/MapHeaders.h>
 #include <noggit/tool_enums.hpp>
+#include <util/sExtendableArray.hpp>
 
 #include <memory>
 
 class MapTile;
-class sExtendableArray;
 
 class TileWater
 {
@@ -21,7 +21,7 @@ public:
   ChunkWater* getChunk(int x, int z);
 
   void readFromFile(MPQFile &theFile, size_t basePos);
-  void saveToFile(sExtendableArray &lADTFile, int &lMHDR_Position, int &lCurrentPosition);
+  void saveToFile(util::sExtendableArray &lADTFile, int &lMHDR_Position, int &lCurrentPosition);
 
   void draw ( math::frustum const& frustum
             , const float& cull_distance

--- a/src/noggit/liquid_layer.cpp
+++ b/src/noggit/liquid_layer.cpp
@@ -237,7 +237,7 @@ liquid_layer& liquid_layer::operator=(liquid_layer const& other)
   return *this;
 }
 
-void liquid_layer::save(sExtendableArray& adt, int base_pos, int& info_pos, int& current_pos) const
+void liquid_layer::save(util::sExtendableArray& adt, int base_pos, int& info_pos, int& current_pos) const
 {
   int min_x = 9, min_z = 9, max_x = 0, max_z = 0;
   bool filled = true;

--- a/src/noggit/liquid_layer.cpp
+++ b/src/noggit/liquid_layer.cpp
@@ -311,7 +311,7 @@ void liquid_layer::save(sExtendableArray& adt, int base_pos, int& info_pos, int&
     {
       for (int x = info.xOffset; x <= info.xOffset + info.width; ++x)
       {
-        memcpy(adt.GetPointer<char>(current_pos), &_vertices[z * 9 + x].y, sizeof(float));
+        memcpy(adt.GetPointer<char>(current_pos).get(), &_vertices[z * 9 + x].y, sizeof(float));
         current_pos += sizeof(float);
       }
     }
@@ -329,7 +329,7 @@ void liquid_layer::save(sExtendableArray& adt, int base_pos, int& info_pos, int&
         uv.x = static_cast<std::uint16_t>(std::min(_tex_coords[z * 9 + x].x * 255.f, 65535.f));
         uv.y = static_cast<std::uint16_t>(std::min(_tex_coords[z * 9 + x].y * 255.f, 65535.f));
 
-        memcpy(adt.GetPointer<char>(current_pos), &uv, sizeof(mh2o_uv));
+        memcpy(adt.GetPointer<char>(current_pos).get(), &uv, sizeof(mh2o_uv));
         current_pos += sizeof(mh2o_uv);
       }
     }
@@ -344,13 +344,13 @@ void liquid_layer::save(sExtendableArray& adt, int base_pos, int& info_pos, int&
       for (int x = info.xOffset; x <= info.xOffset + info.width; ++x)
       {
         std::uint8_t depth = static_cast<std::uint8_t>(std::min(_depth[z * 9 + x] * 255.0f, 255.f));
-        memcpy(adt.GetPointer<char>(current_pos), &depth, sizeof(std::uint8_t));
+        memcpy(adt.GetPointer<char>(current_pos).get(), &depth, sizeof(std::uint8_t));
         current_pos += sizeof(std::uint8_t);
       }
     }
   }
 
-  memcpy(adt.GetPointer<char>(info_pos), &info, sizeof(MH2O_Information));
+  memcpy(adt.GetPointer<char>(info_pos).get(), &info, sizeof(MH2O_Information));
   info_pos += sizeof(MH2O_Information);
 }
 

--- a/src/noggit/liquid_layer.hpp
+++ b/src/noggit/liquid_layer.hpp
@@ -6,10 +6,9 @@
 #include <noggit/MapHeaders.h>
 #include <noggit/liquid_render.hpp>
 #include <opengl/scoped.hpp>
+#include <util/sExtendableArray.hpp>
 
 class MapChunk;
-class sExtendableArray;
-
 
 // handle liquids like oceans, lakes, rivers, slime, magma
 class liquid_layer
@@ -26,7 +25,7 @@ public:
   liquid_layer& operator=(liquid_layer&&);
   liquid_layer& operator=(liquid_layer const& other);
 
-  void save(sExtendableArray& adt, int base_pos, int& info_pos, int& current_pos) const;
+  void save(util::sExtendableArray& adt, int base_pos, int& info_pos, int& current_pos) const;
 
   void draw ( liquid_render& render
             , opengl::scoped::use_program& water_shader

--- a/src/noggit/map_index.cpp
+++ b/src/noggit/map_index.cpp
@@ -158,7 +158,7 @@ void MapIndex::save()
 
   //NOGGIT_LOG << "Saving WDT \"" << filename << "\"." << std::endl;
 
-  sExtendableArray wdtFile = sExtendableArray();
+  util::sExtendableArray wdtFile;
   int curPos = 0;
 
   // MVER
@@ -223,7 +223,7 @@ void MapIndex::save()
   }
 
   MPQFile f(filename.str());
-  f.setBuffer(wdtFile.data);
+  f.setBuffer(wdtFile.all_data());
   f.SaveFile();
   f.close();
 

--- a/src/util/sExtendableArray.cpp
+++ b/src/util/sExtendableArray.cpp
@@ -1,0 +1,36 @@
+// This file is part of Noggit3, licensed under GNU General Public License (version 3).
+
+#include <util/sExtendableArray.hpp>
+
+namespace util
+{
+  void sExtendableArray::Allocate (unsigned long pSize)
+  {
+    data.resize (pSize);
+  }
+
+  void sExtendableArray::Extend (long pAddition)
+  {
+    data.resize (data.size() + pAddition);
+  }
+
+  void sExtendableArray::Insert (unsigned long pPosition, unsigned long pAddition)
+  {
+    std::vector<char> tmp (pAddition);
+    data.insert (data.begin() + pPosition, tmp.begin(), tmp.end());
+  }
+
+  void sExtendableArray::Insert (unsigned long pPosition, unsigned long pAddition, const char * pAdditionalData)
+  {
+    data.insert (data.begin() + pPosition, pAdditionalData, pAdditionalData + pAddition);
+  }
+
+  std::vector<char> sExtendableArray::all_data() const
+  {
+    return data;
+  }
+
+  sExtendableArray::sExtendableArray(unsigned long pSize, const char *pData)
+    : data (pData, pData + pSize)
+  {}
+}

--- a/src/util/sExtendableArray.cpp
+++ b/src/util/sExtendableArray.cpp
@@ -4,11 +4,6 @@
 
 namespace util
 {
-  void sExtendableArray::Allocate (unsigned long pSize)
-  {
-    data.resize (pSize);
-  }
-
   void sExtendableArray::Extend (long pAddition)
   {
     data.resize (data.size() + pAddition);
@@ -27,7 +22,11 @@ namespace util
 
   std::vector<char> sExtendableArray::all_data() const
   {
-    return data;
+    return data_up_to (data.size());
+  }
+  std::vector<char> sExtendableArray::data_up_to (std::size_t position) const
+  {
+    return std::vector<char> (data.begin(), data.begin() + position);
   }
 
   sExtendableArray::sExtendableArray(unsigned long pSize, const char *pData)

--- a/src/util/sExtendableArray.hpp
+++ b/src/util/sExtendableArray.hpp
@@ -1,0 +1,53 @@
+// This file is part of Noggit3, licensed under GNU General Public License (version 3).
+
+#pragma once
+
+#include <vector>
+
+namespace util
+{
+  //! \todo This name is horrible. The API is mediocre.
+  class sExtendableArray
+  {
+    std::vector<char> data;
+
+  public:
+    void Allocate (unsigned long pSize);
+
+    //! Equivalent to `Allocate ($size + pAddition)`.
+    void Extend (long pAddition);
+
+    //! At \a pPosition, insert \a pAddition bytes that are all '\0',
+    //! moving existing data further back.
+    void Insert (unsigned long pPosition, unsigned long pAddition);
+
+    //! At \a pPosition, insert \a pAddition bytes with the data at \a
+    //! pAdditionalData, moving existing data further back.
+    void Insert (unsigned long pPosition, unsigned long pAddition, const char * pAdditionalData);
+
+    template<typename T>
+      struct LazyPointer
+    {
+      LazyPointer (std::vector<char>& data, std::size_t position);
+      T* get() const;
+      T& operator*() const;
+      T* operator->() const;
+      T& operator[] (std::size_t) const;
+      LazyPointer<T>& operator+= (std::size_t);
+
+    private:
+      std::vector<char>& _data;
+      std::size_t _position;
+    };
+
+    template<typename To>
+      LazyPointer<To> GetPointer(unsigned long pPosition = 0);
+
+    std::vector<char> all_data() const;
+
+    sExtendableArray() = default;
+    sExtendableArray(unsigned long pSize, const char *pData);
+  };
+}
+
+#include <util/sExtendableArray.ipp>

--- a/src/util/sExtendableArray.hpp
+++ b/src/util/sExtendableArray.hpp
@@ -12,8 +12,6 @@ namespace util
     std::vector<char> data;
 
   public:
-    void Allocate (unsigned long pSize);
-
     //! Equivalent to `Allocate ($size + pAddition)`.
     void Extend (long pAddition);
 
@@ -44,6 +42,7 @@ namespace util
       LazyPointer<To> GetPointer(unsigned long pPosition = 0);
 
     std::vector<char> all_data() const;
+    std::vector<char> data_up_to (std::size_t position) const;
 
     sExtendableArray() = default;
     sExtendableArray(unsigned long pSize, const char *pData);

--- a/src/util/sExtendableArray.ipp
+++ b/src/util/sExtendableArray.ipp
@@ -1,0 +1,47 @@
+// This file is part of Noggit3, licensed under GNU General Public License (version 3).
+
+namespace util
+{
+  template<typename To>
+    sExtendableArray::LazyPointer<To> sExtendableArray::GetPointer
+      (unsigned long pPosition)
+  {
+    return {data, pPosition};
+  }
+
+  template<typename T>
+      sExtendableArray::LazyPointer<T>::LazyPointer
+        (std::vector<char>& data, std::size_t position)
+    : _data (data)
+    , _position (position)
+  {}
+
+  template<typename T>
+    T* sExtendableArray::LazyPointer<T>::get() const
+  {
+    return reinterpret_cast<T*> (_data.data() + _position);
+  }
+  template<typename T>
+    T& sExtendableArray::LazyPointer<T>::operator*() const
+  {
+    return *get();
+  }
+  template<typename T>
+    T* sExtendableArray::LazyPointer<T>::operator->() const
+  {
+    return get();
+  }
+  template<typename T>
+    T& sExtendableArray::LazyPointer<T>::operator[] (std::size_t i) const
+  {
+    return *(get() + i);
+  }
+
+  template<typename T>
+    sExtendableArray::LazyPointer<T>&
+      sExtendableArray::LazyPointer<T>::operator+= (std::size_t num)
+  {
+    _position += num * sizeof (T);
+    return *this;
+  }
+}


### PR DESCRIPTION
> 01:41 Jamey: the adt file mcnk chunk header gave me a write access violation because my pointer to it got invalidated because Extend calls resize and that might invalidate iterators  
> 01:41 Jamey: I'm unsure if you 'd put that blame on C++ or on Noggit's underlying system

Yeah, the API is horrible. To at least somewhat prevent errors like this, don't give out pointers but a wrapper that only calculates the pointer when using.