### PR TITLE
Script hooks for MH2O flags and MH2O_Render reading fix

### DIFF
--- a/scripts/docs/api/classes/chunk.md
+++ b/scripts/docs/api/classes/chunk.md
@@ -19,14 +19,21 @@ Represents a chunk in the world
 - [clear\_colors](chunk.md#clear_colors)
 - [clear\_textures](chunk.md#clear_textures)
 - [get\_area\_id](chunk.md#get_area_id)
+- [get\_deep\_flag](chunk.md#get_deep_flag)
+- [get\_deep\_flag\_high](chunk.md#get_deep_flag_high)
 - [get\_effect](chunk.md#get_effect)
+- [get\_fishable\_flag](chunk.md#get_fishable_flag)
+- [get\_fishable\_flag\_high](chunk.md#get_fishable_flag_high)
 - [get\_tex](chunk.md#get_tex)
 - [get\_texture](chunk.md#get_texture)
 - [get\_texture\_count](chunk.md#get_texture_count)
 - [get\_vert](chunk.md#get_vert)
+- [has\_render\_flags](chunk.md#has_render_flags)
 - [remove\_texture](chunk.md#remove_texture)
 - [set\_area\_id](chunk.md#set_area_id)
+- [set\_deep\_flag](chunk.md#set_deep_flag)
 - [set\_effect](chunk.md#set_effect)
+- [set\_fishable\_flag](chunk.md#set_fishable_flag)
 - [set\_hole](chunk.md#set_hole)
 - [set\_impassable](chunk.md#set_impassable)
 - [to\_selection](chunk.md#to_selection)
@@ -142,6 +149,35 @@ Returns the area id of a chunk
 
 ___
 
+### get\_deep\_flag
+
+▸ **get_deep_flag**(): *number*
+
+Returns the lower bits of the deep flag
+for the water in this chunk.
+
+If chunk has no render data, 0 is returned
+
+**`note`** Only contains the lower 32 bits.
+      For the higher bits, use get_fishable_flag_high
+
+**Returns:** *number*
+
+___
+
+### get\_deep\_flag\_high
+
+▸ **get_deep_flag_high**(): *number*
+
+Returns the higher bits of the fishable flag
+for the water in this chunk.
+
+If chunk has no render data, 0 is returned
+
+**Returns:** *number*
+
+___
+
 ### get\_effect
 
 ▸ **get_effect**(`layer`: *number*): *number*
@@ -153,6 +189,35 @@ Returns the effect id at a texture layer
 Name | Type |
 :------ | :------ |
 `layer` | *number* |
+
+**Returns:** *number*
+
+___
+
+### get\_fishable\_flag
+
+▸ **get_fishable_flag**(): *number*
+
+Returns the lower bits of the fishable flag
+for the water in this chunk.
+
+If chunk has no render data, 0xffffffff is returned
+
+**`note`** Only contains the lower 32 bits.
+      For the higher bits, use get_fishable_flag_high
+
+**Returns:** *number*
+
+___
+
+### get\_fishable\_flag\_high
+
+▸ **get_fishable_flag_high**(): *number*
+
+Returns the higher bits of the fishable flag
+for the water in this chunk.
+
+If chunk has no render data, 0xffffffff is returned
 
 **Returns:** *number*
 
@@ -216,6 +281,16 @@ Name | Type | Description |
 
 ___
 
+### has\_render\_flags
+
+▸ **has_render_flags**(): *any*
+
+Returns true if the water in this chunk has deep/fishable flag data.
+
+**Returns:** *any*
+
+___
+
 ### remove\_texture
 
 ▸ **remove_texture**(`index`: *number*): *void*
@@ -249,6 +324,27 @@ Name | Type |
 
 ___
 
+### set\_deep\_flag
+
+▸ **set_deep_flag**(`low`: *number*, `high?`: *number*): *void*
+
+Sets the deep flags for the water in this chunk.
+If the first bit is set (it is for value=1), emulators typically interpret this
+to mean fatigue should be applied here.
+
+-high is 0 by default.
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`low` | *number* |
+`high?` | *number* |
+
+**Returns:** *void*
+
+___
+
 ### set\_effect
 
 ▸ **set_effect**(`layer`: *number*, `effect`: *number*): *any*
@@ -263,6 +359,26 @@ Name | Type | Description |
 `effect` | *number* | effect id to set (-1 to remove effects)    |
 
 **Returns:** *any*
+
+___
+
+### set\_fishable\_flag
+
+▸ **set_fishable_flag**(`low`: *number*, `high?`: *number*): *void*
+
+Sets the fishable flag for the water in this chunk.
+If render flag data is not present, it is automatically created.
+
+- high is 0 by default
+
+#### Parameters:
+
+Name | Type |
+:------ | :------ |
+`low` | *number* |
+`high?` | *number* |
+
+**Returns:** *void*
 
 ___
 

--- a/scripts/global.d.ts
+++ b/scripts/global.d.ts
@@ -305,6 +305,66 @@ declare class chunk {
      * @param index valid in range [0-144]
      */
     get_vert(index: number): vert;
+
+    /**
+     * Returns true if the water in this chunk has deep/fishable flag data.
+     */
+    has_render_flags(): bool
+
+    /**
+     * Sets the fishable flag for the water in this chunk.
+     * If render flag data is not present, it is automatically created.
+     *
+     * - high is 0 by default
+     */
+    set_fishable_flag(low: number, high?: number): void;
+
+    /**
+     * Returns the lower bits of the fishable flag
+     * for the water in this chunk.
+     *
+     * If chunk has no render data, 0xffffffff is returned
+     *
+     * @note Only contains the lower 32 bits.
+     *       For the higher bits, use get_fishable_flag_high
+     */
+    get_fishable_flag(): number;
+
+    /**
+     * Returns the higher bits of the fishable flag
+     * for the water in this chunk.
+     *
+     * If chunk has no render data, 0xffffffff is returned
+     */
+    get_fishable_flag_high(): number;
+
+    /**
+     * Sets the deep flags for the water in this chunk.
+     * If the first bit is set (it is for value=1), emulators typically interpret this
+     * to mean fatigue should be applied here.
+     *
+     * -high is 0 by default.
+     */
+    set_deep_flag(low: number, high?: number): void;
+
+    /**
+     * Returns the lower bits of the deep flag
+     * for the water in this chunk.
+     *
+     * If chunk has no render data, 0 is returned
+     *
+     * @note Only contains the lower 32 bits.
+     *       For the higher bits, use get_fishable_flag_high
+     */
+    get_deep_flag(): number;
+
+    /**
+     * Returns the higher bits of the fishable flag
+     * for the water in this chunk.
+     *
+     * If chunk has no render data, 0 is returned
+     */
+    get_deep_flag_high(): number;
 }
 
 /**

--- a/src/noggit/ChunkWater.cpp
+++ b/src/noggit/ChunkWater.cpp
@@ -66,7 +66,7 @@ void ChunkWater::fromFile(MPQFile &f, size_t basePos)
   //render
   if (header.ofsRenderMask)
   {
-    f.seek(basePos + header.ofsRenderMask + sizeof(MH2O_Render));
+    f.seek(basePos + header.ofsRenderMask);
     f.read(&Render, sizeof(MH2O_Render));
   }
 

--- a/src/noggit/ChunkWater.hpp
+++ b/src/noggit/ChunkWater.hpp
@@ -15,6 +15,12 @@ class MPQFile;
 class sExtendableArray;
 class MapChunk;
 
+namespace noggit {
+    namespace scripting {
+        class chunk;
+    }
+}
+
 class ChunkWater
 {
 public:
@@ -88,4 +94,6 @@ private:
   MH2O_Render Render;
 
   std::vector<liquid_layer> _layers;
+
+  friend noggit::scripting::chunk;
 };

--- a/src/noggit/ChunkWater.hpp
+++ b/src/noggit/ChunkWater.hpp
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <set>
+#include <optional>
 
 class MPQFile;
 class sExtendableArray;
@@ -90,10 +91,9 @@ private:
 
   void copy_height_to_layer(liquid_layer& target, math::vector_3d const& pos, float radius);
 
-
-  MH2O_Render Render;
+  std::optional<MH2O_Render> Render;
 
   std::vector<liquid_layer> _layers;
 
-  friend noggit::scripting::chunk;
+  friend class noggit::scripting::chunk;
 };

--- a/src/noggit/scripting/script_chunk.cpp
+++ b/src/noggit/scripting/script_chunk.cpp
@@ -149,9 +149,37 @@ namespace noggit
       return vert(state(), _chunk, index);
     }
 
+    bool chunk::has_render_flags()
+    {
+        return _chunk->liquid_chunk()->Render.has_value();
+    }
+
+    MH2O_Render chunk::getRenderOrDefault()
+    {
+        std::optional<MH2O_Render>& render = _chunk->liquid_chunk()->Render;
+        if (render.has_value())
+        {
+            return render.value();
+        }
+        else
+        {
+            return { 0xFFFFFFFFFFFFFFFF,1 };
+        }
+    }
+
+    MH2O_Render & chunk::getOrCreateRender()
+    {
+        std::optional<MH2O_Render>& render = _chunk->liquid_chunk()->Render;
+        if (!render.has_value())
+        {
+            render.emplace();
+        }
+        return render.value();
+    }
+
     void chunk::set_deep_flag(std::uint32_t low, std::uint32_t high)
     {
-        _chunk->liquid_chunk()->Render.fatigue = std::uint64_t(low)|(std::uint64_t(high)<<32);
+        getOrCreateRender().fatigue = std::uint64_t(low)|(std::uint64_t(high)<<32);
     }
 
     void chunk::set_deep_flag_1(std::uint32_t low)
@@ -159,19 +187,19 @@ namespace noggit
         set_deep_flag(low, 0);
     }
 
-    uint32_t chunk::get_deep_flag()
+    std::uint32_t chunk::get_deep_flag()
     {
-        return _chunk->liquid_chunk()->Render.fatigue;
+        return static_cast<std::uint32_t>(getRenderOrDefault().fatigue);
     }
 
-    uint32_t chunk::get_deep_flag_high()
+    std::uint32_t chunk::get_deep_flag_high()
     {
-        return _chunk->liquid_chunk()->Render.fatigue>>32;
+        return static_cast<std::uint32_t>(getRenderOrDefault().fatigue>>32);
     }
 
     void chunk::set_fishable_flag(std::uint32_t low, std::uint32_t high)
     {
-        _chunk->liquid_chunk()->Render.fishable = std::uint64_t(low) | (std::uint64_t(high) << 32);
+        getOrCreateRender().fishable = std::uint64_t(low) | (std::uint64_t(high) << 32);
     }
 
     void chunk::set_fishable_flag_1(std::uint32_t low)
@@ -181,11 +209,11 @@ namespace noggit
 
     std::uint32_t chunk::get_fishable_flag()
     {
-        return _chunk->liquid_chunk()->Render.fishable;
+        return static_cast<std::uint32_t>(getRenderOrDefault().fishable);
     }
     std::uint32_t chunk::get_fishable_flag_high()
     {
-        return _chunk->liquid_chunk()->Render.fishable>>32;
+        return static_cast<std::uint32_t>(getRenderOrDefault().fishable>>32);
     }
 
     std::shared_ptr<selection> chunk::to_selection()

--- a/src/noggit/scripting/script_chunk.cpp
+++ b/src/noggit/scripting/script_chunk.cpp
@@ -11,6 +11,7 @@
 #include <noggit/MapHeaders.h>
 #include <noggit/MapView.h>
 #include <noggit/World.h>
+#include <noggit/ChunkWater.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 namespace noggit
@@ -148,6 +149,45 @@ namespace noggit
       return vert(state(), _chunk, index);
     }
 
+    void chunk::set_deep_flag(std::uint32_t low, std::uint32_t high)
+    {
+        _chunk->liquid_chunk()->Render.fatigue = std::uint64_t(low)|(std::uint64_t(high)<<32);
+    }
+
+    void chunk::set_deep_flag_1(std::uint32_t low)
+    {
+        set_deep_flag(low, 0);
+    }
+
+    uint32_t chunk::get_deep_flag()
+    {
+        return _chunk->liquid_chunk()->Render.fatigue;
+    }
+
+    uint32_t chunk::get_deep_flag_high()
+    {
+        return _chunk->liquid_chunk()->Render.fatigue>>32;
+    }
+
+    void chunk::set_fishable_flag(std::uint32_t low, std::uint32_t high)
+    {
+        _chunk->liquid_chunk()->Render.fishable = std::uint64_t(low) | (std::uint64_t(high) << 32);
+    }
+
+    void chunk::set_fishable_flag_1(std::uint32_t low)
+    {
+        set_fishable_flag(low, 0);
+    }
+
+    std::uint32_t chunk::get_fishable_flag()
+    {
+        return _chunk->liquid_chunk()->Render.fishable;
+    }
+    std::uint32_t chunk::get_fishable_flag_high()
+    {
+        return _chunk->liquid_chunk()->Render.fishable>>32;
+    }
+
     std::shared_ptr<selection> chunk::to_selection()
     {
       return std::make_shared<selection>(state(), "chunk#to_selection", _chunk->vmin,_chunk->vmax);
@@ -183,7 +223,19 @@ namespace noggit
         , "to_selection", &chunk::to_selection
         , "get_tex", &chunk::get_tex
         , "get_vert", &chunk::get_vert
-      ); 
+        , "set_deep_flag", sol::overload(
+            &chunk::set_deep_flag
+          , &chunk::set_deep_flag_1
+          )
+        , "get_deep_flag", &chunk::get_deep_flag
+        , "get_deep_flag_high", &chunk::get_deep_flag_high
+        , "set_fishable_flag", sol::overload(
+            &chunk::set_fishable_flag
+          , &chunk::set_fishable_flag_1
+        )
+        , "get_fishable_flag", &chunk::get_fishable_flag
+        , "get_fishable_flag_high", &chunk::get_fishable_flag_high
+        );
     }
   } // namespace scripting
 } // namespace noggit

--- a/src/noggit/scripting/script_chunk.hpp
+++ b/src/noggit/scripting/script_chunk.hpp
@@ -4,6 +4,7 @@
 #include <noggit/scripting/script_vert.hpp>
 #include <noggit/scripting/script_object.hpp>
 #include <noggit/MapChunk.h>
+#include <cstdint>
 
 namespace noggit
 {
@@ -32,6 +33,17 @@ namespace noggit
       void apply_heightmap();
       void apply_vertex_color();
       void apply_all();
+
+      void set_deep_flag(std::uint32_t low, std::uint32_t high);
+      void set_deep_flag_1(std::uint32_t low);
+      std::uint32_t get_deep_flag();
+      std::uint32_t get_deep_flag_high();
+
+      void set_fishable_flag(std::uint32_t low, std::uint32_t high);
+      void set_fishable_flag_1(std::uint32_t low);
+      std::uint32_t get_fishable_flag();
+      std::uint32_t get_fishable_flag_high();
+
       void set_impassable(bool add);
       int get_area_id();
       void set_area_id(int value);

--- a/src/noggit/scripting/script_chunk.hpp
+++ b/src/noggit/scripting/script_chunk.hpp
@@ -43,6 +43,7 @@ namespace noggit
       void set_fishable_flag_1(std::uint32_t low);
       std::uint32_t get_fishable_flag();
       std::uint32_t get_fishable_flag_high();
+      bool has_render_flags();
 
       void set_impassable(bool add);
       int get_area_id();
@@ -51,6 +52,8 @@ namespace noggit
       vert get_vert(int index);
       std::shared_ptr<selection> to_selection();
     private:
+      MH2O_Render getRenderOrDefault();
+      MH2O_Render& getOrCreateRender();
       MapChunk* _chunk;
       friend class selection;
     };


### PR DESCRIPTION
## Additions
1. Adds script hooks to write MH2O_Render flags, used in emulators to check for deep / shallow ocean
2. Fixes issue where noggit incorrectly reads written MH2O_Render data to make this usable. 
3. Makes MH2O_Render an optional chunk of ChunkWater, as it isn't always present in ADTs and emulators may not agree with us on what values should be default ([they currently don't](https://github.com/TrinityCore/TrinityCore/blob/d0fd8e683ca02f3d2d9ceefe55482a49aab59c6c/src/tools/map_extractor/adt.h#L241)).

## Explanations
Before 7d684e896d3eae8a7e00fd3374c57739161ffecc, read MH2O_Render was garbage, and I've verified this frequently caused any saved chunks with ocean to be incorrectly re-written as deep ocean.

This is why it generally defaulted to being read as deep by emulators, despite technically being garbage:
https://github.com/TrinityCore/TrinityCore/blob/04909bada85d4770a58a5b2b6f2180f5aacb1b81/src/tools/map_extractor/System.cpp#L710

## Remaining work
(This has all been implemented, see point 3)
~~Typically, the way blizzard seems to do deep ocean is to just not have MH2O_Render data at all (which, in emulators, is read as their values defaulting to 0xFFFFFF..., and therefore deep), but currently noggit will [automatically create missing MH2O_Render chunks](https://github.com/wowdev/noggit3/blob/d2723e5340fc63860c55884281f461d896fff66d/src/noggit/ChunkWater.hpp#L88) that [has the deep flag initialized to 0](https://github.com/wowdev/noggit3/blob/d2723e5340fc63860c55884281f461d896fff66d/src/noggit/MapHeaders.h#L216), which after the _first_ save will be interpreted as non-deep, but because of the previous reading bug will become garbage unlikely to be 0 and thus read as deep by emulators again. With this fix, it would start making deep ocean shallow instead of the opposite, since they would now continue to be rewritten as 0 even after consecutive reads. It's possible the fact a lot of old continents use mclq causes it to skip the first step entirely and never showing the skip issue in deep ocean, but immediately showing the garbage issue for shallow ocean.~~

~~I can see two ways to solve this:~~

~~1. Do not create MH2O_Render data unless user explicitly tries to write it or it's converted from mclq, since it's an optional chunk. (This has now been implemented)~~
~~2. Continue to create MH2O_Render data automatically, but initialize the deep flag to 1 since that's how blizzard and all the emulators interpret it. This feels like a hack, but should at least not cause any more bugs and might be preferrable if we just want to make sure the data is always there (+ slightly easier to implement).~~