### PR TITLE
noggit: add object transform sensitivity modifiers

### DIFF
--- a/src/noggit/MapView.h
+++ b/src/noggit/MapView.h
@@ -141,6 +141,7 @@ private:
 
   bool MoveObj;
   float numpad_moveratio = 0.001f;
+  float obj_transform_sens = 1.0f;
 
   math::vector_3d objMove;
 

--- a/src/noggit/ui/Help.cpp
+++ b/src/noggit/ui/Help.cpp
@@ -280,6 +280,9 @@ namespace noggit
       generate_hotkey_row({ font_noggit::shift },                                                        "Holding \a 1 / 3 - Double speed", object_layout);
       generate_hotkey_row({ font_noggit::ctrl },                                                         "Holding \a 1 / 3 - Triple speed", object_layout);
       generate_hotkey_row({ font_noggit::shift, font_noggit::ctrl },                                     "Holding \a and \a together - half speed", object_layout);
+      generate_hotkey_row({ font_noggit::k },                                                            "\a Decrease object transform sensitivity", object_layout);
+      generate_hotkey_row({ font_noggit::l },                                                            "\a Increase object transform sensitivity", object_layout);
+
 
       auto shader_widget (new QWidget (this));
       auto shader_layout (new QFormLayout (shader_widget));


### PR DESCRIPTION
## Feature
Allows lower sensitivity when moving/rotating/scaling objects with mouse, makes it far easier to connect things like fences

![sensitivity](https://user-images.githubusercontent.com/76849026/142642666-c99a3d32-67be-4a1d-8efe-1c02973d4522.gif)

## Usage
Press k/l keys in object mode to change transformation sensitivity, ~4 stages

## Notes
- Setting is not applicable for "Mouse follow cursor on the ground".

## To do
- Try it out, check some sensitivity settings. I think 0.05 as a lowest allows me to do everything i'd want, but maybe there's some use-case i'm not considering. I see no reason to allow it to go above 1.0

- Are these good hotkeys to use? I put them close to O/P since that's close to the buttons used for camera sensitivity

- Tablet test?