### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,10 +8,13 @@ jobs:
         include:
           - platform: ubuntu-18.04
             compiler: g++-9
+            compiler_c: gcc-9
           - platform: ubuntu-18.04
             compiler: clang++-9
+            compiler_c: clang-9
           - platform: windows-2019
             compiler: msvc2019 ## == vs 16
+            compiler_c: msvc2019
     runs-on: ${{ matrix.platform }}
     name: ${{ matrix.platform }}-${{ matrix.compiler }}
     steps:
@@ -51,7 +54,7 @@ jobs:
     - name: "dependency: stormlib"
       run: |
         git clone "https://github.com/ladislav-zezula/StormLib" "${{ runner.workspace }}/stormlib"
-        cmake -B "${{ runner.workspace }}/stormlib/build" -S "${{ runner.workspace }}/stormlib" -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_INSTALL_PREFIX="${{ runner.workspace }}/stormlib/install" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake -B "${{ runner.workspace }}/stormlib/build" -S "${{ runner.workspace }}/stormlib" -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_INSTALL_PREFIX="${{ runner.workspace }}/stormlib/install" -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
         cmake --install "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
 

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -54,7 +54,7 @@ jobs:
     - name: "dependency: stormlib"
       run: |
         git clone "https://github.com/ladislav-zezula/StormLib" "${{ runner.workspace }}/stormlib"
-        cmake -B "${{ runner.workspace }}/stormlib/build" -S "${{ runner.workspace }}/stormlib" -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_C_COMPILER=${{ matrix.c_compiler }} -DCMAKE_INSTALL_PREFIX="${{ runner.workspace }}/stormlib/install" -DCMAKE_BUILD_TYPE=RelWithDebInfo
+        cmake -B "${{ runner.workspace }}/stormlib/build" -S "${{ runner.workspace }}/stormlib" -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_C_COMPILER=${{ matrix.compiler_c }} -DCMAKE_INSTALL_PREFIX="${{ runner.workspace }}/stormlib/install" -DCMAKE_BUILD_TYPE=RelWithDebInfo
         cmake --build "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
         cmake --install "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -767,6 +767,8 @@ if (NOGGIT_WITH_SCRIPTING)
     PATCH_COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_SOURCE_DIR}/cmake/deps/patch_fastnoise2.cmake"
     UPDATE_DISCONNECTED true
   )
+
+  set(FASTNOISE2_NOISETOOL OFF CACHE BOOL "")
   FetchContent_GetProperties (fastnoise2)
   if (NOT fastnoise2_POPULATED)
     message (STATUS "Installing FastNoise2... (big repo, large download)")
@@ -805,4 +807,5 @@ if (NOGGIT_WITH_SCRIPTING)
     nlohmann_json::nlohmann_json
     sol2::sane
   )
+
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@ option (VALIDATE_OPENGL_PROGRAMS "Validate Opengl programs" ON)
 
 include ("cmake/add_compiler_flag_if_supported.cmake")
 
-add_global_compiler_flag_if_supported (-fcolor-diagnostics)
-
 add_noggit_compiler_flag_if_supported (-Werror=reorder)
 add_noggit_compiler_flag_if_supported (-Werror=conditional-uninitialized)
 add_noggit_compiler_flag_if_supported (-Werror=unused)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ elseif (WIN32)
   set(ResFiles media/res.rc)
 endif()
 
-option (NOGGIT_WITH_SCRIPTING "Enable scripting support?" ON)
+set(NOGGIT_WITH_SCRIPTING OFF CACHE BOOL "Enabling scripting support?")
 
 include_directories ("${CMAKE_CURRENT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/tmp")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,11 @@ add_noggit_compiler_flag_if_supported (-Wno-padded)
 
 # msvc++ mangles struct/class into name, thus symbols may be called differently
 # with a bad forward-decl. we want compilation to fail, not linking.
-add_global_compiler_flag_if_supported (/we4099)
-add_global_compiler_flag_if_supported (-Werror=mismatched-tags)
+# todo: i assume this check should really be done inside "add_global_compiler_flag_if_supported"
+if (WIN32)
+  add_global_compiler_flag_if_supported (/we4099)
+  add_global_compiler_flag_if_supported (-Werror=mismatched-tags)
+endif()
 
 # yes, we intend to use multi-character character constants
 add_global_compiler_flag_if_supported (-Wno-multichar)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,7 +104,6 @@ add_global_compiler_flag_if_supported_config (/Ob2 Release RelWithDebInfo) # inl
 add_global_compiler_flag_if_supported_config (/Oi Release RelWithDebInfo)  # enable intrasic functions
 add_global_compiler_flag_if_supported_config (/Ot Release RelWithDebInfo)  # favor fast code
 add_global_compiler_flag_if_supported_config (/GL Release RelWithDebInfo)  # whole program optimization
-add_global_compiler_flag_if_supported_config (-flto Release RelWithDebInfo)
 add_global_compiler_flag_if_supported_config (-O3 Release RelWithDebInfo)
 
 SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/")

--- a/src/noggit/ChunkWater.hpp
+++ b/src/noggit/ChunkWater.hpp
@@ -96,4 +96,5 @@ private:
   std::vector<liquid_layer> _layers;
 
   friend class noggit::scripting::chunk;
+  friend class MapView;
 };

--- a/src/noggit/MapView.cpp
+++ b/src/noggit/MapView.cpp
@@ -2220,7 +2220,6 @@ void MapView::tick (float dt)
               if (waterchunk->hasData(0))
               {
                   liquid_layer liquid = waterchunk->_layers[0]; // only getting data from layer 0, maybe loop them ?
-                  int liquid_flags = liquid._subchunks;
 
                   select_info << "\nliquid type: " << liquid._liquid_id << " (\"" << gLiquidTypeDB.getLiquidName(liquid._liquid_id) << "\")"
                               << "\nliquid flags: "

--- a/src/noggit/liquid_layer.hpp
+++ b/src/noggit/liquid_layer.hpp
@@ -104,4 +104,6 @@ private:
 
 private:
   math::vector_3d pos;
+
+  friend class MapView;
 };

--- a/src/noggit/texture_set.cpp
+++ b/src/noggit/texture_set.cpp
@@ -413,7 +413,7 @@ bool TextureSet::paintTexture(float xbase, float zbase, float x, float z, Brush*
 
         for (int n = 0; n < 4; ++n)
         {
-          total += alpha_values[n] = amaps[n][offset];
+          total += alpha_values[n] = amaps[n][i + 64 * j];
         }
 
         double current_alpha = alpha_values[tex_layer];
@@ -501,7 +501,7 @@ bool TextureSet::paintTexture(float xbase, float zbase, float x, float z, Brush*
 
           for (int n = 0; n < 4; ++n)
           {
-            amaps[n][offset] = static_cast<float>(alpha_values[n]);
+            amaps[n][i + 64 * j] = static_cast<float>(alpha_values[n]);
           }
 
           changed = true;


### PR DESCRIPTION
Fixes CI builds for all platforms

Currently disables a few flags in cmake, might want to look over if some of those are important enough to check for them explicitly. I guess the proper solution is that the function called `add_noggit_compiler_flag_if_supported` handles that, but probably better to merge this if it works as the master is currently broken for normal builds as well.

[My latest run](https://github.com/ihm-tswow/noggit3/actions/runs/1818353662).