### PR TITLE
GitHub CI: bump Ubuntu version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,13 +6,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - platform: ubuntu-20.04
-            compiler: g++-9
-            compiler_c: gcc-9
+          - platform: ubuntu-24.04
+            compiler: g++-14
+            compiler_c: gcc-14
             extra_cmake_args: -GNinja
-          - platform: ubuntu-20.04
-            compiler: clang++-10
-            compiler_c: clang-10
+          - platform: ubuntu-24.04
+            compiler: clang++-18
+            compiler_c: clang-18
             extra_cmake_args: -GNinja
           - platform: windows-2019
             compiler: msvc2019 ## == vs 16
@@ -27,18 +27,15 @@ jobs:
       run: |
         wget "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage" -O "${{ runner.workspace }}/linuxdeployqt"
         chmod +x "${{ runner.workspace }}/linuxdeployqt"
-      if: ${{ matrix.platform == 'ubuntu-20.04' }}
+      if: ${{ matrix.platform == 'ubuntu-24.04' }}
 
-    - name: "dependency: clang (linux)"
-      run: sudo apt update && sudo apt install clang-10
-      if: ${{ matrix.platform == 'ubuntu-20.04' && matrix.compiler == 'clang++-10' }}
     - name: "dependency: ninja (linux)"
       run: sudo apt update && sudo apt install ninja-build
-      if: ${{ matrix.platform == 'ubuntu-20.04' }}
+      if: ${{ matrix.platform == 'ubuntu-24.04' }}
 
     - name: "dependency: qt5 (linux)"
-      run: sudo apt update && sudo apt install -y qtbase5-dev qt5-default
-      if: ${{ matrix.platform == 'ubuntu-20.04' }}
+      run: sudo apt update && sudo apt install -y qtbase5-dev
+      if: ${{ matrix.platform == 'ubuntu-24.04' }}
     - name: "dependency: qt5 (windows)"
       uses: jurplel/install-qt-action@v4
       with:
@@ -75,12 +72,12 @@ jobs:
         echo 'Icon=default' >> "${{ github.workspace }}/install/default.desktop"
         echo 'Categories=Game;' >> "${{ github.workspace }}/install/default.desktop"
         "${{ runner.workspace }}/linuxdeployqt" "${{ github.workspace }}/install/noggit" -appimage -bundle-non-qt-libs -no-strip -verbose=2
-      if: ${{ matrix.platform == 'ubuntu-20.04' }}
+      if: ${{ matrix.platform == 'ubuntu-24.04' }}
     - uses: actions/upload-artifact@v4
       with:
         name: ${{ matrix.platform }}-${{ matrix.compiler }}-appimage
         path: Noggit*.AppImage
-      if: ${{ matrix.platform == 'ubuntu-20.04' }}
+      if: ${{ matrix.platform == 'ubuntu-24.04' }}
 
     - run: |
         mkdir dependencies/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -56,6 +56,10 @@ jobs:
         cmake --build "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
         cmake --install "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
 
+    - name: "dependency: fuse (linux, appimage)"
+      run: sudo apt update && sudo apt install libfuse2
+      if: ${{ matrix.platform == 'ubuntu-24.04' }}
+
     - name: "configure"
       run: cmake -Wdev -Wdeprecated --warn-uninitialized -B "${{ github.workspace }}/build" -S "${{ github.workspace }}" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_PREFIX_PATH="${{ runner.workspace }}/stormlib/install" ${{ matrix.extra_cmake_args }}
     - name: "build"

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -53,9 +53,9 @@ jobs:
         cmake --build "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
         cmake --install "${{ runner.workspace }}/stormlib/build" --config RelWithDebInfo
 
-    - name: "dependency: fuse (linux, appimage)"
-      run: sudo apt update && sudo apt install libfuse2
-      if: ${{ matrix.platform == 'ubuntu-24.04' }}
+    #- name: "dependency: fuse (linux, appimage)"
+    #  run: sudo apt update && sudo apt install libfuse2
+    #  if: ${{ matrix.platform == 'ubuntu-24.04' }}
 
     - name: "configure"
       run: cmake -Wdev -Wdeprecated --warn-uninitialized -B "${{ github.workspace }}/build" -S "${{ github.workspace }}" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_CXX_COMPILER=${{ matrix.compiler }} -DCMAKE_PREFIX_PATH="${{ runner.workspace }}/stormlib/install" ${{ matrix.extra_cmake_args }}
@@ -64,20 +64,22 @@ jobs:
     - name: "install"
       run: cmake --install "${{ github.workspace }}/build" --prefix "${{ github.workspace }}/install" --config RelWithDebInfo
 
-    - name: "release: appimage (linux)"
-      run: |
-        echo '[Desktop Entry]' > "${{ github.workspace }}/install/default.desktop"
-        echo 'Type=Application' >> "${{ github.workspace }}/install/default.desktop"
-        echo 'Name=Noggit 3' >> "${{ github.workspace }}/install/default.desktop"
-        echo 'Icon=default' >> "${{ github.workspace }}/install/default.desktop"
-        echo 'Categories=Game;' >> "${{ github.workspace }}/install/default.desktop"
-        "${{ runner.workspace }}/linuxdeployqt" "${{ github.workspace }}/install/noggit" -appimage -bundle-non-qt-libs -no-strip -verbose=2
-      if: ${{ matrix.platform == 'ubuntu-24.04' }}
-    - uses: actions/upload-artifact@v4
-      with:
-        name: ${{ matrix.platform }}-${{ matrix.compiler }}-appimage
-        path: Noggit*.AppImage
-      if: ${{ matrix.platform == 'ubuntu-24.04' }}
+    # \todo linuxdeployqt requires Ubuntu 20.04 for glibc version stability. Check whether they bumped the
+    # requirement at some point since 20.04 will be dropped from GitHub CI.
+    #- name: "release: appimage (linux)"
+    #  run: |
+    #    echo '[Desktop Entry]' > "${{ github.workspace }}/install/default.desktop"
+    #    echo 'Type=Application' >> "${{ github.workspace }}/install/default.desktop"
+    #    echo 'Name=Noggit 3' >> "${{ github.workspace }}/install/default.desktop"
+    #    echo 'Icon=default' >> "${{ github.workspace }}/install/default.desktop"
+    #    echo 'Categories=Game;' >> "${{ github.workspace }}/install/default.desktop"
+    #    "${{ runner.workspace }}/linuxdeployqt" "${{ github.workspace }}/install/noggit" -appimage -bundle-non-qt-libs -no-strip -verbose=2
+    #  if: ${{ matrix.platform == 'ubuntu-24.04' }}
+    #- uses: actions/upload-artifact@v4
+    #  with:
+    #    name: ${{ matrix.platform }}-${{ matrix.compiler }}-appimage
+    #    path: Noggit*.AppImage
+    #  if: ${{ matrix.platform == 'ubuntu-24.04' }}
 
     - run: |
         mkdir dependencies/

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -46,6 +46,9 @@ jobs:
         arch: win64_msvc2019_64
       if: ${{ matrix.platform == 'windows-2019' }}
 
+    - name: "dependency: bzip2 (linux, stormlib)"
+      run: sudo apt update && sudo apt install libbz2-dev
+      if: ${{ matrix.platform == 'ubuntu-24.04' }}
     - name: "dependency: stormlib"
       run: |
         git clone "https://github.com/ladislav-zezula/StormLib" "${{ runner.workspace }}/stormlib"

--- a/cmake/add_compiler_flag_if_supported.cmake
+++ b/cmake/add_compiler_flag_if_supported.cmake
@@ -9,7 +9,15 @@ include(CheckCXXSourceCompiles)
 include(CMakeCheckCompilerFlagCommonPatterns)
 
 macro (CHECK_CXX_COMPILER_FLAG _FLAG _RESULT)
-  set(SAFE_CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}")
+## end copy ]]
+  set(cccf_do_save_crd false)
+  if(DEFINED CMAKE_REQUIRED_DEFINITIONS)
+    set(cccf_do_save_crd true)
+## begin copy [[
+    set(SAFE_CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}")
+## end copy ]]
+  endif()
+## begin copy [[
   set(CMAKE_REQUIRED_DEFINITIONS "${_FLAG}")
 ## end copy ]]
 
@@ -40,7 +48,13 @@ macro (CHECK_CXX_COMPILER_FLAG _FLAG _RESULT)
     )
   foreach(v ${_CheckCXXCompilerFlag_LOCALE_VARS})
     if (DEFINED _CheckCXXCompilerFlag_SAVED_${v})
-      set(ENV{${v}} ${${_CheckCXXCompilerFlag_SAVED_${v}}})
+## end copy ]]
+      if(DEFINED ${_CheckCXXCompilerFlag_SAVED_${v}})
+## begin copy [[
+        set(ENV{${v}} ${${_CheckCXXCompilerFlag_SAVED_${v}}})
+## end copy ]]
+      endif()
+## begin copy [[
       unset(_CheckCXXCompilerFlag_SAVED_${v})
     else()
       unset (ENV{${v}})
@@ -49,7 +63,15 @@ macro (CHECK_CXX_COMPILER_FLAG _FLAG _RESULT)
   unset(_CheckCXXCompilerFlag_LOCALE_VARS)
   unset(_CheckCXXCompilerFlag_COMMON_PATTERNS)
 
-  set (CMAKE_REQUIRED_DEFINITIONS "${SAFE_CMAKE_REQUIRED_DEFINITIONS}")
+## end copy ]]
+  if(cccf_do_save_crd)
+## begin copy [[
+    set (CMAKE_REQUIRED_DEFINITIONS "${SAFE_CMAKE_REQUIRED_DEFINITIONS}")
+## end copy ]]
+  else()
+    unset(CMAKE_REQUIRED_DEFINITIONS)
+  endif()
+## begin copy [[
 endmacro ()
 ## end copy ]]
 

--- a/src/noggit/DBC.h
+++ b/src/noggit/DBC.h
@@ -4,6 +4,7 @@
 
 #include <noggit/DBCFile.h>
 
+#include <cstdint>
 #include <string>
 
 class AreaDB : public DBCFile

--- a/src/noggit/Misc.h
+++ b/src/noggit/Misc.h
@@ -7,16 +7,17 @@
 #include <math/vector_3d.hpp>
 #include <math/vector_4d.hpp>
 #include <noggit/Log.h>
+#include <noggit/Selection.h>
 #include <util/sExtendableArray.hpp>
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <string>
 #include <vector>
-#include <noggit/Selection.h>
 
 // namespace for static helper functions.
 

--- a/src/noggit/World.h
+++ b/src/noggit/World.h
@@ -185,7 +185,7 @@ private:
 public:
 
   noggit::gizmo gizmo;
-  std::optional<math::vector_3d> const& multi_select_pivot() const { return _grouped_models.pivot(); }
+  std::optional<math::vector_3d> multi_select_pivot() const { return _grouped_models.pivot(); }
 
   // Selection related methods.
   bool is_selected(selection_type selection) const;

--- a/src/noggit/bookmarks.hpp
+++ b/src/noggit/bookmarks.hpp
@@ -5,6 +5,7 @@
 #include <math/vector_3d.hpp>
 #include <math/trig.hpp>
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
> https://github.com/actions/runner-images/issues/11101 The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. 

The bump is somewhat straight forward, except for https://github.com/probonopd/linuxdeployqt/issues/340, which has our Linux AppImage releases require Ubuntu 20.04, which is still alive until April as well.

We can either bump now and re-enable releases later (in case anyone even ever notices), or pick the first five commits now and the sixth in April. 