### PR TITLE
Script Brush Fixes

### DIFF
--- a/src/noggit/scripting/script_chunk.cpp
+++ b/src/noggit/scripting/script_chunk.cpp
@@ -105,6 +105,7 @@ namespace noggit
     void chunk::apply_vertex_color()
     {
       _chunk->require_vertices_buffer_update();
+      _chunk->texture_set_changed();
     }
 
     void chunk::apply_all()

--- a/src/noggit/scripting/script_global.cpp
+++ b/src/noggit/scripting/script_global.cpp
@@ -27,6 +27,16 @@ namespace noggit {
       { 
         // note: we set both min/max random scale and the normal scale parameter,
         // because noggit picks one based on random scale settings in the object tool
+        if (!MPQFile::exists(filename))
+        {
+          throw script_exception(
+            "add_m2",
+            std::string("M2 not exist:\n")
+            + "\""
+            + filename
+            + "\""
+          );
+        }
         object_paste_params p;
         p.minScale = scale;
         p.maxScale = scale;
@@ -43,6 +53,17 @@ namespace noggit {
         , math::vector_3d const& pos
         , math::vector_3d const& rotation)
       {
+        if (!MPQFile::exists(filename))
+        {
+          throw script_exception(
+            "add_wmo",
+            std::string("WMO not exist:\n")
+            + "\""
+            + filename
+            + "\""
+          );
+        }
+
         global->get_view()->_world.get()->addWMO(
             filename
           , pos

--- a/src/noggit/scripting/script_global.cpp
+++ b/src/noggit/scripting/script_global.cpp
@@ -63,7 +63,6 @@ namespace noggit {
             + "\""
           );
         }
-
         global->get_view()->_world.get()->addWMO(
             filename
           , pos

--- a/src/noggit/scripting/script_tex.cpp
+++ b/src/noggit/scripting/script_tex.cpp
@@ -24,13 +24,23 @@ namespace noggit {
     float tex::get_alpha(int index)
     {
       auto& ts = _chunk->texture_set;
+      if(!ts||index<1||index>=ts->nTextures)
+      {
+        throw script_exception(
+            "tex_get_alpha",
+            std::string("invalid texture layer: ")
+          + std::to_string(index)
+          + std::string(" (in call to tex_get_alpha)")
+          );
+      }
       ts->create_temporary_alphamaps_if_needed();
       return ts->tmp_edit_values.get()->operator[](index)[_index];
     }
 
     void tex::set_alpha(int index, float value)
     {
-      if(index<0||index>3)
+      auto& ts = _chunk->texture_set;
+      if(!ts||index<1||index>=ts->nTextures) 
       {
         throw script_exception(
             "tex_set_alpha",
@@ -39,10 +49,9 @@ namespace noggit {
           + std::string(" (in call to tex_set_alpha)")
           );
       }
-      auto& ts = _chunk->texture_set;
-      ts->create_temporary_alphamaps_if_needed();
-      ts->tmp_edit_values.get()->operator[](index)[_index] = value;
-    }
+        ts->create_temporary_alphamaps_if_needed();
+        ts->tmp_edit_values.get()->operator[](index)[_index] = value;
+      }
 
     namespace {
       math::vector_3d tex_location(MapChunk* chnk, int index)

--- a/src/noggit/scripting/script_tex.cpp
+++ b/src/noggit/scripting/script_tex.cpp
@@ -46,7 +46,6 @@ namespace noggit {
             "tex_set_alpha",
             std::string("invalid texture layer: ")
           + std::to_string(index)
-          + std::string(" (in call to tex_set_alpha)")
           );
       }
       ts->create_temporary_alphamaps_if_needed();

--- a/src/noggit/scripting/script_tex.cpp
+++ b/src/noggit/scripting/script_tex.cpp
@@ -49,8 +49,8 @@ namespace noggit {
           + std::string(" (in call to tex_set_alpha)")
           );
       }
-        ts->create_temporary_alphamaps_if_needed();
-        ts->tmp_edit_values.get()->operator[](index)[_index] = value;
+      ts->create_temporary_alphamaps_if_needed();
+      ts->tmp_edit_values.get()->operator[](index)[_index] = value;
     }
 
     namespace {

--- a/src/noggit/scripting/script_tex.cpp
+++ b/src/noggit/scripting/script_tex.cpp
@@ -40,7 +40,7 @@ namespace noggit {
     void tex::set_alpha(int index, float value)
     {
       auto& ts = _chunk->texture_set;
-      if(!ts||index<1||index>=ts->nTextures) 
+      if(!ts||index<1||index>=ts->nTextures)
       {
         throw script_exception(
             "tex_set_alpha",
@@ -51,7 +51,7 @@ namespace noggit {
       }
         ts->create_temporary_alphamaps_if_needed();
         ts->tmp_edit_values.get()->operator[](index)[_index] = value;
-      }
+    }
 
     namespace {
       math::vector_3d tex_location(MapChunk* chnk, int index)

--- a/src/noggit/scripting/script_tex.cpp
+++ b/src/noggit/scripting/script_tex.cpp
@@ -30,7 +30,6 @@ namespace noggit {
             "tex_get_alpha",
             std::string("invalid texture layer: ")
           + std::to_string(index)
-          + std::string(" (in call to tex_get_alpha)")
           );
       }
       ts->create_temporary_alphamaps_if_needed();


### PR DESCRIPTION
I'm proud to present the long-awaited update!
After extensive delays (since release 3378), the script brush can be used again!

1. Fixed a bug where changes to vertex colors were not displayed in real-time.  
2. Added a path validation for models (when a model is copied from the world or WMV, "\n" was being added to its path, causing it not to display).
3. Added safety checks for set/get if the requested texture layer is missing from the chunk.