### PR TITLE
mpq: 2x faster normalization

### DIFF
--- a/src/noggit/MPQ.cpp
+++ b/src/noggit/MPQ.cpp
@@ -338,24 +338,18 @@ namespace noggit
   {
     std::string normalized_filename (std::string filename)
     {
-      std::transform (filename.begin(), filename.end(), filename.begin(), [](unsigned char c) { return std::tolower(c); });
-      std::transform ( filename.begin(), filename.end(), filename.begin()
-                     , [] (char c)
-                       {
-                         return c == '\\' ? '/' : c;
-                       }
-                     );
+      for (char& c : filename)
+      {
+        c = (c == '\\') ? '/' : std::tolower(c);
+      }
       return filename;
     }
     std::string normalized_filename_insane (std::string filename)
     {
-      std::transform (filename.begin(), filename.end(), filename.begin(), [](unsigned char c) { return std::toupper(c); });
-      std::transform ( filename.begin(), filename.end(), filename.begin()
-                     , [] (char c)
-                       {
-                         return c == '/' ? '\\' : c;
-                       }
-                     );
+      for (char& c : filename)
+      {
+        c = (c == '/') ? '\\' : std::toupper(c);
+      }
       return filename;
     }
   }


### PR DESCRIPTION
Sorry, couldn't resist.

Looking at  `normalized_filename()`, I couldn't shake the thought: 'I wonder how often this runs when loading chunks?' 
Turns out - way too often (more than 200 thousand times just for loading a single chunk).
Then came another idea - 'why not cut its execution time in half?':"
```
                     , [] (char c)
                       {
                         return c == '\\' ? '/' : std::tolower(c);
                       }
                     );
```
Then it hit me - 'we can make it even faster!' - and here's what I implemented:
```
      for (char& c : filename)
      {
        c = (c == '\\') ? '/' : std::tolower(c);
      }
```
**Needs test checking on other systems.**

I ran two "benchmarks":

1. Load Azetoth_31_51
2. Walking to Stratholme

Here are the results:

| Version | Single chunk (ms) | Walk to Strat(ms) |
|:------|:-----:|-------:|
| Original     | 1182 | 7833 |
| Single-pass     | 785 | 5025  |
| For loop     | 673 | 4182  |


And also: QTString  processes single chunk loading in 550ms, but spends an additional 400ms converting to std::string .
And same operations using the boost  library take as long as 3000ms.


![normlze](https://github.com/user-attachments/assets/ca36bae5-756c-440c-820a-ce0fe48b9afd)

